### PR TITLE
Fix linux step typo, update ports

### DIFF
--- a/apps/docs/technical/develop-pipeline/local-testing.mdx
+++ b/apps/docs/technical/develop-pipeline/local-testing.mdx
@@ -33,7 +33,7 @@ We will use the [ComfyStream_Setup_Scripts](https://github.com/ryanontheinside/C
         <Note>
             When deploying new pods from the network volume you will need to run this initialization command again.
         </Note>
-        6. Start a *new* SSH terminal session in your pod for the change to take effect. You should see `(base)` to the left of the terminal cursor.
+        6. Start a new terminal session in your pod for the change to take effect. You should see `(base)` to the left of the terminal cursor.
     </Tab>
     <Tab title="Local (Windows)">
         1. Clone the ComfyStream Setup Scripts to your home directory

--- a/apps/docs/technical/develop-pipeline/local-testing.mdx
+++ b/apps/docs/technical/develop-pipeline/local-testing.mdx
@@ -132,7 +132,7 @@ conda activate comfystream
 <Tabs>
     <Tab title="RunPod (Linux)">
         ```bash
-        cd /workspace/comfyRealtime/comfystream
+        cd /workspace/comfyRealtime/ComfyStream
         ```
     </Tab>
 

--- a/apps/docs/technical/reference/tunneling-with-ssh.mdx
+++ b/apps/docs/technical/reference/tunneling-with-ssh.mdx
@@ -39,5 +39,9 @@ Traffic sent to localhost:1234 on the local machine will be forwarded over the S
 Open another terminal, ssh into the remote SSH terminal:
 
 - You should find "SSH over exposed TCP" value in Runpod
-- Copy that command, and `add -L 8888:localhost:8888`
-    - For example: `ssh -L 8888:localhost:8888 root@{runpod_ip} -p 16974 -i ~/.ssh/id_ed25519`
+- Copy that command, and `add -L 8889:localhost:8889`
+    - For example: `ssh -L 8889:localhost:8889 root@{runpod_ip} -p 16974 -i ~/.ssh/id_ed25519`
+
+<Note>
+8889 is the port that ComfyStream is listening on at the remote server
+</Note>


### PR DESCRIPTION
- Fix typo in linux install steps for custom nodes
- Update port for ComfyStream to use 8889 instead of 8888 for both linux/windows to improve consistency and avoid conflicts with juptyer lab on RunPod