### PR TITLE
Improve startup time by changing the backoffMax from `30s` (default) to `1s`

### DIFF
--- a/apps/app/components/playground/player.tsx
+++ b/apps/app/components/playground/player.tsx
@@ -26,7 +26,7 @@ export function LPPLayer({
   return (
     <div className="aspect-video">
       <iframe
-        src={`https://${isProduction() ? "lvpr.tv" : "monster.lvpr.tv"}/?v=${output_playback_id}&lowLatency=force`}
+        src={`https://${isProduction() ? "lvpr.tv" : "monster.lvpr.tv"}/?v=${output_playback_id}&lowLatency=force&backoffMax=1000`}
         className="w-full h-full"
       />
     </div>


### PR DESCRIPTION
Related lvpr.tv change: https://github.com/livepeer/ui-kit/pull/585