### PR TITLE
update hf model repository name

### DIFF
--- a/apps/docs/technical/reference/download-models.mdx
+++ b/apps/docs/technical/reference/download-models.mdx
@@ -30,13 +30,13 @@ wget "https://civitai.com/api/download/models/128713?token=YOUR_TOKEN_HERE" --co
 ### Checkpoints
 ```bash
 cd /workspace/comfyRealtime/ComfyUI/
-huggingface-cli download pschroedl/comfystream_checkpoints --local-dir models/checkpoints --include "*.safetensors"
+huggingface-cli download Livepeer-Studio/comfystream_checkpoints --local-dir models/checkpoints --include "*.safetensors"
 ```
 
 ### LoRas
 ```bash
 cd /workspace/comfyRealtime/ComfyUI/
-huggingface-cli download pschroedl/comfystream_loras --local-dir models/loras --include "*.safetensors"
+huggingface-cli download Livepeer-Studio/comfystream_loras --local-dir models/loras --include "*.safetensors"
 huggingface-cli download RalFinger/alien-style-lora-sdxl --local-dir models/loras --include "*.safetensors"
 ```
 


### PR DESCRIPTION
Updates the "Download Models" article to refer to the official Livepeer-Studio hugging face repo for checkpoint and lora models

- https://huggingface.co/Livepeer-Studio/comfystream_checkpoints

- https://huggingface.co/Livepeer-Studio/comfystream_loras