### PR TITLE
pipelines: fetch stream status & sse status api

### DIFF
--- a/apps/app/app/api/pipelines/validation.ts
+++ b/apps/app/app/api/pipelines/validation.ts
@@ -3,6 +3,52 @@ import { createServerClient } from "@repo/supabase";
 import { serverConfig } from "@/lib/serverEnv";
 import { app } from "@/lib/env";
 
+type StatusRequest = {
+  headers: {
+    'Authorization': string
+  },
+  url: string
+}
+
+export type StreamStatus = {
+  input_fps: number
+  last_error: any
+  last_error_time: any
+  last_input_time: number
+  last_output_time: any
+  last_params: any
+  last_params_hash: string
+  last_params_update_time: any
+  last_restart_logs: any
+  last_restart_time: number
+  orchestrator_info: OrchestratorInfo
+  output_fps: number
+  pipeline: string
+  pipeline_id: string
+  request_id: string
+  restart_count: number
+  start_time: number
+  stream_id: string
+  type: string
+}
+
+export type OrchestratorInfo = {
+  address: string
+  url: string
+}
+
+const MAX_POLL_ATTEMPTS = 60;
+const POLL_INTERVAL = 5000;
+
+// Declare the map in the global scope since the pipelines and the streams api are running in different processes
+declare global {
+  var streamStatusMap: Map<string, any>;
+}
+
+if (!global.streamStatusMap) {
+  global.streamStatusMap = new Map();
+}
+
 export async function createSmokeTestStream(pipelineId: string) {
   const supabase = await createServerClient();
   const { data: pipeline, error } = await supabase
@@ -27,6 +73,8 @@ export async function createSmokeTestStream(pipelineId: string) {
     throw new Error(streamError);
   }
 
+  pollStreamStatus(stream);
+
   return stream;
 }
 
@@ -39,9 +87,6 @@ export async function triggerSmokeTest(streamKey: string) {
   const credentials = Buffer.from(`${username}:${password}`).toString("base64");
   
   const streamUrl = `${app.rtmpUrl}${app.rtmpUrl?.endsWith('/') ? '' : '/'}${streamKey}`;
-
-  console.log("Triggering smoke test for stream:", streamUrl);
-  console.log("Gateway URL:", gatewayUrl);
 
   try {
     const response = await fetch(`${gatewayUrl}/smoketest`, {
@@ -64,4 +109,103 @@ export async function triggerSmokeTest(streamKey: string) {
     console.error("Error making smoke test API call:", error);
     throw error;
   }
+}
+
+export async function pollStreamStatus(stream: any) {
+  const supabase = await createServerClient();
+  const streamId = stream.id;
+  const { gateway } = await serverConfig();
+  const username = gateway.userId;
+  const password = gateway.password;
+  
+  // Wait for gateway_host to be available
+  const waitForGatewayHost = async () => {
+    let retries = 0;
+    const maxRetries = 10;
+    
+    while (retries < maxRetries) {
+      const { data: s, error } = await supabase
+        .from("streams")
+        .select("*")
+        .eq("id", streamId)
+        .single();
+        
+      if (error) throw new Error(error.message);
+      if (s.gateway_host) {
+        return s;
+      }
+      
+      console.log("Waiting for gateway_host to be available...");
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      retries++;
+    }
+    throw new Error("Timeout waiting for gateway_host");
+  };
+
+  stream = await waitForGatewayHost();
+  
+  const statusBaseUrl = `https://${stream.gateway_host}/live/video-to-video`;
+
+  let request: StatusRequest = {
+    headers: {
+      'Authorization': `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
+    },
+    url: `${statusBaseUrl}/${streamId}/status`
+  }
+
+  if (!request.url) throw new Error("Status base URL is undefined");
+
+  let attempts = 0;
+
+  try {
+    while (attempts < MAX_POLL_ATTEMPTS) {
+      try {
+        await getAndStoreStreamStatus(request, streamId);
+        await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL));
+        attempts++;
+      } catch (error) {
+        if (error instanceof Error && error.message.includes('404')) {
+          // Stream status not available or not found
+          await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL));
+          attempts++;
+          continue;
+        }
+        console.error('Polling error:', error);
+        global.streamStatusMap.delete(streamId); 
+        break;
+      }
+    }
+    
+    if (attempts >= MAX_POLL_ATTEMPTS) {
+      console.log('Max polling attempts reached');
+      global.streamStatusMap.delete(streamId);
+    }
+  } catch (error) {
+    console.error('Unexpected polling error:', error);
+    global.streamStatusMap.delete(streamId);
+  }
+}
+
+export async function getAndStoreStreamStatus(request: StatusRequest, streamId: string) {
+  
+  const response = await fetch(request.url, {
+    headers: request.headers,
+    method: 'GET',
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error('404 Not Found');
+    }
+    throw new Error(`Failed to fetch stream status: ${response.statusText}`);
+  }
+
+  const data: StreamStatus = await response.json();
+  global.streamStatusMap.set(streamId, data);
+
+  return data;
+}
+
+export async function getStoredStreamStatus(streamId: string): Promise<StreamStatus | undefined> {
+  return global.streamStatusMap.get(streamId);
 }

--- a/apps/app/app/api/streams/[id]/sse/route.ts
+++ b/apps/app/app/api/streams/[id]/sse/route.ts
@@ -1,0 +1,41 @@
+import { getStoredStreamStatus } from "@/app/api/pipelines/validation";
+
+// Prevents this route's response from being cached on Vercel
+export const dynamic = "force-dynamic";
+ 
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const encoder = new TextEncoder()
+  const streamId = params.id
+
+  const customReadable = new ReadableStream({
+    async start(controller) {
+      controller.enqueue(encoder.encode(`data: {"message": "Connected to SSE stream"}\n\n`))
+      
+      const interval = setInterval(async () => {
+        const status = await getStoredStreamStatus(streamId)
+        
+        if (status) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(status)}\n\n`))
+        } else {
+          controller.enqueue(encoder.encode(`data: {"message": "Stream status data not available yet or Stream not found"}\n\n`))
+        }
+      }, 5000)
+
+      request.signal.addEventListener('abort', () => {
+        clearInterval(interval)
+      })
+    },
+  })
+
+  return new Response(customReadable, {
+    headers: {
+      Connection: "keep-alive",
+      "Content-Encoding": "none",
+      "Cache-Control": "no-cache, no-transform",
+      "Content-Type": "text/event-stream; charset=utf-8",
+    },
+  })
+}


### PR DESCRIPTION
- Fetch the stream status for the give smoke test stream on pipeline creation
- Store the stream status in-memory by key
- create a new sse api `streamId/sse` to receive status updates for the frontend to display smoke test results

NOTE: There is already a GET api under `[streamId]/status` that directly calls the Gateway - we might want to use that one as soon as the gateway itself exposes a real-time api for stream statuses