### PR TITLE
feat: cleanup broadcast on page change

### DIFF
--- a/apps/app/components/playground/broadcast.tsx
+++ b/apps/app/components/playground/broadcast.tsx
@@ -36,128 +36,130 @@ export function BroadcastWithControls({
     };
   }, [onUnmount]);
 
-  return !ingestUrl ? (
-    <BroadcastLoading
-      title="Invalid stream key"
-      description="The stream key provided was invalid. Please check and try again."
-    />
-  ) : (
-    <>
-      <Broadcast.Root
-        onError={(error) =>
-          error?.type === "permissions"
-            ? toast.error(
-                "You must accept permissions to broadcast. Please try again."
-              )
-            : null
-        }
-        forceEnabled={true}
-        audio={false}
-        aspectRatio={16 / 9}
-        ingestUrl={ingestUrl}
-      >
-        <Broadcast.Container className="w-full h-full text-white/50 overflow-hidden rounded-sm bg-gray-950">
-          <Broadcast.Video
-            title="Live stream"
-            className="w-full h-full text-white/50"
-          />
-          <Broadcast.LoadingIndicator className="w-full relative h-full">
-            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
-              <LoadingIcon className="w-8 h-8 animate-spin" />
+  if (!ingestUrl) {
+    return (
+      <BroadcastLoading
+        title="Invalid stream key"
+        description="The stream key provided was invalid. Please check and try again."
+      />
+    );
+  }
+
+  return (
+    <Broadcast.Root
+      onError={(error) =>
+        error?.type === "permissions"
+          ? toast.error(
+              "You must accept permissions to broadcast. Please try again."
+            )
+          : null
+      }
+      forceEnabled={true}
+      audio={false}
+      aspectRatio={16 / 9}
+      ingestUrl={ingestUrl}
+    >
+      <Broadcast.Container className="w-full h-full text-white/50 overflow-hidden rounded-sm bg-gray-950">
+        <Broadcast.Video
+          title="Live stream"
+          className="w-full h-full text-white/50"
+        />
+        <Broadcast.LoadingIndicator className="w-full relative h-full">
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+            <LoadingIcon className="w-8 h-8 animate-spin" />
+          </div>
+          <BroadcastLoading />
+        </Broadcast.LoadingIndicator>
+        <Broadcast.ErrorIndicator
+          matcher="not-permissions"
+          className="absolute select-none inset-0 text-center bg-gray-950 flex flex-col items-center justify-center gap-4 duration-1000 data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0"
+        >
+          <OfflineErrorIcon className="h-[120px] w-full sm:flex hidden" />
+          <div className="flex flex-col gap-1">
+            <div className="text-2xl font-bold">Broadcast failed</div>
+            <div className="text-sm text-gray-100">
+              There was an error with broadcasting - it is retrying in the
+              background.
             </div>
-            <BroadcastLoading />
-          </Broadcast.LoadingIndicator>
-          <Broadcast.ErrorIndicator
-            matcher="not-permissions"
-            className="absolute select-none inset-0 text-center bg-gray-950 flex flex-col items-center justify-center gap-4 duration-1000 data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0"
-          >
-            <OfflineErrorIcon className="h-[120px] w-full sm:flex hidden" />
-            <div className="flex flex-col gap-1">
-              <div className="text-2xl font-bold">Broadcast failed</div>
-              <div className="text-sm text-gray-100">
-                There was an error with broadcasting - it is retrying in the
-                background.
-              </div>
+          </div>
+        </Broadcast.ErrorIndicator>
+        <Broadcast.Controls className="bg-gradient-to-b gap-1 px-3 md:px-3 py-1.5 flex-col-reverse flex from-black/20 via-80% via-black/30 duration-1000 to-black/60 data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0">
+          <div className="flex justify-between gap-4">
+            <div className="flex flex-1 items-center gap-3">
+              <Broadcast.VideoEnabledTrigger className="w-6 h-6 hover:scale-110 transition flex-shrink-0">
+                <Broadcast.VideoEnabledIndicator asChild matcher={false}>
+                  <DisableVideoIcon className="w-full h-full text-white/50" />
+                </Broadcast.VideoEnabledIndicator>
+                <Broadcast.VideoEnabledIndicator asChild matcher={true}>
+                  <EnableVideoIcon className="w-full h-full text-white/50" />
+                </Broadcast.VideoEnabledIndicator>
+              </Broadcast.VideoEnabledTrigger>
+              <Broadcast.AudioEnabledTrigger className="w-6 h-6 hover:scale-110 transition flex-shrink-0">
+                <Broadcast.AudioEnabledIndicator asChild matcher={false}>
+                  <DisableAudioIcon className="w-full h-full text-white/50" />
+                </Broadcast.AudioEnabledIndicator>
+                <Broadcast.AudioEnabledIndicator asChild matcher={true}>
+                  <EnableAudioIcon className="w-full h-full text-white/50" />
+                </Broadcast.AudioEnabledIndicator>
+              </Broadcast.AudioEnabledTrigger>
             </div>
-          </Broadcast.ErrorIndicator>
-          <Broadcast.Controls className="bg-gradient-to-b gap-1 px-3 md:px-3 py-1.5 flex-col-reverse flex from-black/20 via-80% via-black/30 duration-1000 to-black/60 data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0">
-            <div className="flex justify-between gap-4">
-              <div className="flex flex-1 items-center gap-3">
-                <Broadcast.VideoEnabledTrigger className="w-6 h-6 hover:scale-110 transition flex-shrink-0">
-                  <Broadcast.VideoEnabledIndicator asChild matcher={false}>
-                    <DisableVideoIcon className="w-full h-full text-white/50" />
-                  </Broadcast.VideoEnabledIndicator>
-                  <Broadcast.VideoEnabledIndicator asChild matcher={true}>
-                    <EnableVideoIcon className="w-full h-full text-white/50" />
-                  </Broadcast.VideoEnabledIndicator>
-                </Broadcast.VideoEnabledTrigger>
-                <Broadcast.AudioEnabledTrigger className="w-6 h-6 hover:scale-110 transition flex-shrink-0">
-                  <Broadcast.AudioEnabledIndicator asChild matcher={false}>
-                    <DisableAudioIcon className="w-full h-full text-white/50" />
-                  </Broadcast.AudioEnabledIndicator>
-                  <Broadcast.AudioEnabledIndicator asChild matcher={true}>
-                    <EnableAudioIcon className="w-full h-full text-white/50" />
-                  </Broadcast.AudioEnabledIndicator>
-                </Broadcast.AudioEnabledTrigger>
-              </div>
-              <div className="flex sm:flex-1 md:flex-[1.5] justify-end items-center gap-2.5">
-                <Broadcast.FullscreenIndicator matcher={false} asChild>
-                  <Settings className="w-6 h-6 transition flex-shrink-0" />
+            <div className="flex sm:flex-1 md:flex-[1.5] justify-end items-center gap-2.5">
+              <Broadcast.FullscreenIndicator matcher={false} asChild>
+                <Settings className="w-6 h-6 transition flex-shrink-0" />
+              </Broadcast.FullscreenIndicator>
+
+              <Broadcast.ScreenshareTrigger className="w-6 h-6 hover:scale-110 transition flex-shrink-0">
+                <Broadcast.ScreenshareIndicator asChild>
+                  <StopScreenshareIcon className="w-full h-full text-white/50" />
+                </Broadcast.ScreenshareIndicator>
+
+                <Broadcast.ScreenshareIndicator matcher={false} asChild>
+                  <StartScreenshareIcon className="w-full h-full text-white/50" />
+                </Broadcast.ScreenshareIndicator>
+              </Broadcast.ScreenshareTrigger>
+
+              <Broadcast.FullscreenTrigger className="w-6 h-6 hover:scale-110 transition flex-shrink-0">
+                <Broadcast.FullscreenIndicator asChild>
+                  <ExitFullscreenIcon className="w-full h-full text-white/50" />
                 </Broadcast.FullscreenIndicator>
 
-                <Broadcast.ScreenshareTrigger className="w-6 h-6 hover:scale-110 transition flex-shrink-0">
-                  <Broadcast.ScreenshareIndicator asChild>
-                    <StopScreenshareIcon className="w-full h-full text-white/50" />
-                  </Broadcast.ScreenshareIndicator>
-
-                  <Broadcast.ScreenshareIndicator matcher={false} asChild>
-                    <StartScreenshareIcon className="w-full h-full text-white/50" />
-                  </Broadcast.ScreenshareIndicator>
-                </Broadcast.ScreenshareTrigger>
-
-                <Broadcast.FullscreenTrigger className="w-6 h-6 hover:scale-110 transition flex-shrink-0">
-                  <Broadcast.FullscreenIndicator asChild>
-                    <ExitFullscreenIcon className="w-full h-full text-white/50" />
-                  </Broadcast.FullscreenIndicator>
-
-                  <Broadcast.FullscreenIndicator matcher={false} asChild>
-                    <EnterFullscreenIcon className="w-full h-full text-white/50" />
-                  </Broadcast.FullscreenIndicator>
-                </Broadcast.FullscreenTrigger>
-              </div>
+                <Broadcast.FullscreenIndicator matcher={false} asChild>
+                  <EnterFullscreenIcon className="w-full h-full text-white/50" />
+                </Broadcast.FullscreenIndicator>
+              </Broadcast.FullscreenTrigger>
             </div>
-          </Broadcast.Controls>
+          </div>
+        </Broadcast.Controls>
 
-          <Broadcast.LoadingIndicator asChild matcher={false}>
-            <div className="absolute overflow-hidden py-1 px-2 rounded-full top-1 left-1 bg-black/50 flex items-center backdrop-blur">
-              <Broadcast.StatusIndicator
-                matcher="live"
-                className="flex gap-2 items-center"
-              >
-                <div className="bg-red-500 animate-pulse h-1.5 w-1.5 rounded-full" />
-                <span className="text-xs select-none">LIVE</span>
-              </Broadcast.StatusIndicator>
+        <Broadcast.LoadingIndicator asChild matcher={false}>
+          <div className="absolute overflow-hidden py-1 px-2 rounded-full top-1 left-1 bg-black/50 flex items-center backdrop-blur">
+            <Broadcast.StatusIndicator
+              matcher="live"
+              className="flex gap-2 items-center"
+            >
+              <div className="bg-red-500 animate-pulse h-1.5 w-1.5 rounded-full" />
+              <span className="text-xs select-none">LIVE</span>
+            </Broadcast.StatusIndicator>
 
-              <Broadcast.StatusIndicator
-                className="flex gap-2 items-center"
-                matcher="pending"
-              >
-                <div className="bg-white/80 h-1.5 w-1.5 rounded-full animate-pulse" />
-                <span className="text-xs select-none">PENDING</span>
-              </Broadcast.StatusIndicator>
+            <Broadcast.StatusIndicator
+              className="flex gap-2 items-center"
+              matcher="pending"
+            >
+              <div className="bg-white/80 h-1.5 w-1.5 rounded-full animate-pulse" />
+              <span className="text-xs select-none">PENDING</span>
+            </Broadcast.StatusIndicator>
 
-              <Broadcast.StatusIndicator
-                className="flex gap-2 items-center"
-                matcher="idle"
-              >
-                <div className="bg-white/80 h-1.5 w-1.5 rounded-full" />
-                <span className="text-xs select-none">IDLE</span>
-              </Broadcast.StatusIndicator>
-            </div>
-          </Broadcast.LoadingIndicator>
-        </Broadcast.Container>
-      </Broadcast.Root>
-    </>
+            <Broadcast.StatusIndicator
+              className="flex gap-2 items-center"
+              matcher="idle"
+            >
+              <div className="bg-white/80 h-1.5 w-1.5 rounded-full" />
+              <span className="text-xs select-none">IDLE</span>
+            </Broadcast.StatusIndicator>
+          </div>
+        </Broadcast.LoadingIndicator>
+      </Broadcast.Container>
+    </Broadcast.Root>
   );
 }
 

--- a/apps/app/components/playground/broadcast.tsx
+++ b/apps/app/components/playground/broadcast.tsx
@@ -17,15 +17,25 @@ import * as Broadcast from "@livepeer/react/broadcast";
 import * as Popover from "@radix-ui/react-popover";
 import { cn } from "@repo/design-system/lib/utils";
 import { CheckIcon, ChevronDownIcon, XIcon } from "lucide-react";
-import React from "react";
+import React, { useEffect } from "react";
 
 import { toast } from "sonner";
 
 export function BroadcastWithControls({
   ingestUrl,
+  onUnmount,
 }: {
   ingestUrl: string | null;
+  onUnmount?: () => void;
 }) {
+  useEffect(() => {
+    return () => {
+      if (onUnmount) {
+        onUnmount();
+      }
+    };
+  }, [onUnmount]);
+
   return !ingestUrl ? (
     <BroadcastLoading
       title="Invalid stream key"

--- a/apps/app/components/playground/try.tsx
+++ b/apps/app/components/playground/try.tsx
@@ -110,6 +110,7 @@ export default function Try({
   const [streamKey, setStreamKey] = useState<string | null>(null);
   const [streamKilled, setStreamKilled] = useState(false);
   const { timeRemaining } = useTrialTimer();
+  const [isVisible, setIsVisible] = useState(true);
 
   useEffect(() => {
     const handleTrialExpired = () => {
@@ -405,6 +406,12 @@ export default function Try({
     };
   }, []);
 
+  useEffect(() => {
+    return () => {
+      setIsVisible(false);
+    };
+  }, []);
+
   return (
     <>
       <div className={streamKilled ? "opacity-50 pointer-events-none" : ""}>
@@ -648,11 +655,8 @@ export default function Try({
             <div className="flex flex-col gap-1.5">
               <Label className="text-muted-foreground">Video Source</Label>
               <div className="flex flex-row h-[300px] w-full bg-sidebar rounded-2xl items-center justify-center overflow-hidden relative">
-                {streamUrl ? (
-                  <BroadcastWithControls 
-                    ingestUrl={streamUrl} 
-                    onUnmount={handleBroadcastCleanup}
-                  />
+                {streamUrl && isVisible ? (
+                  <BroadcastWithControls ingestUrl={streamUrl} />
                 ) : (
                   <p className="text-muted-foreground">
                     Waiting for webcam to start...

--- a/apps/app/components/playground/try.tsx
+++ b/apps/app/components/playground/try.tsx
@@ -388,6 +388,23 @@ export default function Try({
     }
   };
 
+  const handleBroadcastCleanup = () => {
+    navigator.mediaDevices.getUserMedia({ video: true, audio: true })
+      .then(stream => {
+        stream.getTracks().forEach(track => {
+          track.stop();
+        });
+      })
+      .catch(err => console.error('Error cleaning up media tracks:', err));
+  };
+
+  // Add cleanup effect
+  useEffect(() => {
+    return () => {
+      handleBroadcastCleanup();
+    };
+  }, []);
+
   return (
     <>
       <div className={streamKilled ? "opacity-50 pointer-events-none" : ""}>
@@ -632,7 +649,10 @@ export default function Try({
               <Label className="text-muted-foreground">Video Source</Label>
               <div className="flex flex-row h-[300px] w-full bg-sidebar rounded-2xl items-center justify-center overflow-hidden relative">
                 {streamUrl ? (
-                  <BroadcastWithControls ingestUrl={streamUrl} />
+                  <BroadcastWithControls 
+                    ingestUrl={streamUrl} 
+                    onUnmount={handleBroadcastCleanup}
+                  />
                 ) : (
                   <p className="text-muted-foreground">
                     Waiting for webcam to start...

--- a/apps/app/components/welcome/featured/dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/dreamshaper.tsx
@@ -65,6 +65,23 @@ export default function Dreamshaper({
     }
   };
 
+  const handleBroadcastCleanup = () => {
+    navigator.mediaDevices.getUserMedia({ video: true, audio: true })
+      .then(stream => {
+        stream.getTracks().forEach(track => {
+          track.stop();
+        });
+      })
+      .catch(err => console.error('Error cleaning up media tracks:', err));
+  };
+
+  // Add cleanup effect
+  useEffect(() => {
+    return () => {
+      handleBroadcastCleanup();
+    };
+  }, []);
+
   return (
     <div className="relative flex flex-col h-[calc(100vh-10rem)] overflow-hidden">
       {/* Header section */}
@@ -168,7 +185,10 @@ export default function Dreamshaper({
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : (
-            <BroadcastWithControls ingestUrl={streamUrl} />
+            <BroadcastWithControls 
+              ingestUrl={streamUrl} 
+              onUnmount={handleBroadcastCleanup}
+            />
           )}
         </div>
       ) : (
@@ -178,7 +198,10 @@ export default function Dreamshaper({
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : (
-            <BroadcastWithControls ingestUrl={streamUrl} />
+            <BroadcastWithControls 
+              ingestUrl={streamUrl}
+              onUnmount={handleBroadcastCleanup} 
+            />
           )}
         </div>
       )}

--- a/apps/app/components/welcome/featured/dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/dreamshaper.tsx
@@ -55,6 +55,7 @@ export default function Dreamshaper({
   const { currentPromptIndex } = usePrompts();
   const [inputValue, setInputValue] = useState("");
   const isMobile = useIsMobile();
+  const [isVisible, setIsVisible] = useState(true);
 
   const { authenticated, login } = usePrivy();
   const { timeRemaining, formattedTime } = useTrialTimer();
@@ -79,6 +80,7 @@ export default function Dreamshaper({
   useEffect(() => {
     return () => {
       handleBroadcastCleanup();
+      setIsVisible(false);
     };
   }, []);
 
@@ -185,10 +187,7 @@ export default function Dreamshaper({
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : (
-            <BroadcastWithControls 
-              ingestUrl={streamUrl} 
-              onUnmount={handleBroadcastCleanup}
-            />
+            streamUrl && isVisible && <BroadcastWithControls ingestUrl={streamUrl} />
           )}
         </div>
       ) : (
@@ -198,10 +197,7 @@ export default function Dreamshaper({
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : (
-            <BroadcastWithControls 
-              ingestUrl={streamUrl}
-              onUnmount={handleBroadcastCleanup} 
-            />
+            streamUrl && isVisible && <BroadcastWithControls ingestUrl={streamUrl} />
           )}
         </div>
       )}


### PR DESCRIPTION
Currently, when you are broadcasting and you change the page, you still can see the webcam running in the background, because the Brodacast component is still alive. If you start a new pipeline, this could occur in an ingest error.

This PR should address it, cleaning up the component when another page gets rendered