### PR TITLE
broadcast: enable mic input by default

### DIFF
--- a/apps/app/components/playground/broadcast.tsx
+++ b/apps/app/components/playground/broadcast.tsx
@@ -42,7 +42,7 @@ export function BroadcastWithControls({
             : null
         }
         forceEnabled={true}
-        audio={false}
+        audio={true}
         aspectRatio={16 / 9}
         ingestUrl={ingestUrl}
       >


### PR DESCRIPTION
For audio passthru to work, the player needs to load with mic enabled by default.