### PR TITLE
ui: daydream: camera permission rework

### DIFF
--- a/apps/app/components/daydream/index.tsx
+++ b/apps/app/components/daydream/index.tsx
@@ -25,18 +25,6 @@ export default function DayDreamContent(): ReactElement {
     stream?.id || "",
     false,
   );
-  
-  const setShowInterstitialWithLog = (value: boolean) => {
-    setShowInterstitial(value);
-  };
-  
-  const setCameraPermissionGrantedWithLog = (value: boolean) => {
-    setCameraPermissionGranted(value);
-  };
-  
-  const setShowPromptSelectionWithLog = (value: boolean) => {
-    setShowPromptSelection(value);
-  };
 
   useEffect(() => {
     const checkPermissions = async () => {
@@ -96,9 +84,9 @@ export default function DayDreamContent(): ReactElement {
   }, []);
 
   const handleReady = () => {
-    setShowInterstitialWithLog(false);
+    setShowInterstitial(false);
     setStreamKilled(false);
-    setShowPromptSelectionWithLog(false);
+    setShowPromptSelection(false);
   };
 
   const handlePromptApply = (prompt: string) => {

--- a/apps/app/components/daydream/index.tsx
+++ b/apps/app/components/daydream/index.tsx
@@ -33,11 +33,11 @@ export default function DayDreamContent(): ReactElement {
           const cameraPermission = await navigator.permissions.query({
             name: "camera" as PermissionName,
           });
-          
+
           if (cameraPermission.state === "granted") {
             setCameraPermissionGranted(true);
             const hasVisited = localStorage.getItem("hasSeenLandingPage");
-            
+
             if (hasVisited) {
               setShowInterstitial(false);
             }
@@ -96,14 +96,14 @@ export default function DayDreamContent(): ReactElement {
 
   const handleCameraPermissionGranted = () => {
     setCameraPermissionGranted(true);
-    
+
     const hasSelectedPrompt = localStorage.getItem("hasSelectedPrompt");
     if (!hasSelectedPrompt) {
       setShowPromptSelection(true);
     } else {
       handleReady();
     }
-    
+
     localStorage.removeItem("hasSeenLandingPage");
   };
 
@@ -131,7 +131,7 @@ export default function DayDreamContent(): ReactElement {
           <ClientSideTracker eventName="home_page_view" />
         </div>
       )}
-      
+
       {showInterstitial && (
         <Interstitial
           streamId={stream?.id}

--- a/apps/app/components/daydream/index.tsx
+++ b/apps/app/components/daydream/index.tsx
@@ -46,7 +46,7 @@ export default function DayDreamContent(): ReactElement {
           }
         }
       } catch (err) {
-        // Silent error handling
+        console.error("Error checking camera permission:", err);
       }
     };
 

--- a/apps/app/components/welcome/featured/interstitial.tsx
+++ b/apps/app/components/welcome/featured/interstitial.tsx
@@ -249,6 +249,7 @@ const Interstitial: React.FC<InterstitialProps> = ({
       onCameraPermissionGranted();
       
       setCurrentScreenWithLog("prompts");
+      return true;
     } catch (err) {
       setCameraPermissionWithLog("denied");
       track("daydream_camera_permission_denied", {
@@ -260,6 +261,7 @@ const Interstitial: React.FC<InterstitialProps> = ({
           "Please ensure camera permissions are enabled in your browser settings.",
         );
       }
+      return false;
     }
   };
 
@@ -328,13 +330,16 @@ const Interstitial: React.FC<InterstitialProps> = ({
     }
     
     if (cameraPermission !== "granted") {
-      await requestCamera();
+      const cameraGranted = await requestCamera();
+      if (cameraGranted) {
+        setCurrentScreenWithLog("prompts");
+      }
     } else {
       onCameraPermissionGranted();
       setCurrentScreenWithLog("prompts");
     }
     
-    setCurrentScreenWithLog("prompts");
+    setIsPermissionLoading(false);
   };
 
   const handlePromptContinue = async () => {
@@ -387,7 +392,10 @@ const Interstitial: React.FC<InterstitialProps> = ({
       <AnimatePresence mode="wait" initial={false}>
         {currentScreen === "camera" ? (
           <Slide keyName="camera" slideVariants={slideVariants}>
-            <div className="bg-[#161616] border border-[#232323] rounded-xl p-3 sm:p-4 md:p-8 max-w-2xl w-full mx-auto shadow-lg">
+            <div 
+              className="bg-[#161616] border border-[#232323] rounded-xl p-3 sm:p-4 md:p-8 max-w-2xl w-full mx-auto shadow-lg cursor-pointer"
+              onClick={handlePermissionContinue}
+            >
               <div className="space-y-1 sm:space-y-2 md:space-y-3 mb-3 sm:mb-4 md:mb-8">
                 <h1 className="text-lg sm:text-xl md:text-2xl font-semibold">
                   Enable camera access to start creating
@@ -417,7 +425,9 @@ const Interstitial: React.FC<InterstitialProps> = ({
                   </div>
                 ))}
               </div>
-              <div className="flex flex-col items-center gap-4 mt-8">
+              <div className="flex flex-col items-center gap-4 mt-8"
+                onClick={(e) => e.stopPropagation()}
+              >
                 {(cameraPermission === "prompt" ||
                   cameraPermission === "granted") && (
                   <Button

--- a/apps/app/components/welcome/featured/interstitial.tsx
+++ b/apps/app/components/welcome/featured/interstitial.tsx
@@ -113,26 +113,6 @@ const Interstitial: React.FC<InterstitialProps> = ({
   const [isPermissionLoading, setIsPermissionLoading] = useState(false);
   const [isPromptLoading, setIsPromptLoading] = useState(false);
 
-  const setCameraPermissionWithLog = (value: PermissionState) => {
-    setCameraPermission(value);
-  };
-  
-  const setCurrentScreenWithLog = (value: "camera" | "prompts") => {
-    setCurrentScreen(value);
-  };
-  
-  const setInitialCameraGrantedWithLog = (value: boolean) => {
-    setInitialCameraGranted(value);
-  };
-
-  const setAutoProceededWithLog = (value: boolean) => {
-    setAutoProceeded(value);
-  };
-  
-  const setPermissionsCheckedWithLog = (value: boolean) => {
-    setPermissionsChecked(value);
-  };
-
   const effectiveStreamId = streamId || "";
   const {
     status: streamStatus,
@@ -150,19 +130,19 @@ const Interstitial: React.FC<InterstitialProps> = ({
           });
           const state = permissionStatus.state as PermissionState;
           
-          setCameraPermissionWithLog(state);
+          setCameraPermission(state);
           if (state === "granted") {
-            setInitialCameraGrantedWithLog(true);
+            setInitialCameraGranted(true);
             onCameraPermissionGranted();
           } else {
-            setInitialCameraGrantedWithLog(false);
+            setInitialCameraGranted(false);
           }
         } else {
-          setCameraPermissionWithLog("prompt");
-          setInitialCameraGrantedWithLog(false);
+          setCameraPermission("prompt");
+          setInitialCameraGranted(false);
         }
       } finally {
-        setPermissionsCheckedWithLog(true);
+        setPermissionsChecked(true);
       }
     };
 
@@ -206,10 +186,10 @@ const Interstitial: React.FC<InterstitialProps> = ({
       const hasVisited = localStorage.getItem("hasSeenLandingPage");
       
       if (hasVisited) {
-        setAutoProceededWithLog(true);
+        setAutoProceeded(true);
         onReady();
       } else {
-        setCurrentScreenWithLog("prompts");
+        setCurrentScreen("prompts");
       }
     }
   }, [
@@ -222,7 +202,7 @@ const Interstitial: React.FC<InterstitialProps> = ({
 
   useEffect(() => {
     if (showPromptSelection) {
-      setCurrentScreenWithLog("prompts");
+      setCurrentScreen("prompts");
     }
   }, [showPromptSelection]);
 
@@ -242,16 +222,16 @@ const Interstitial: React.FC<InterstitialProps> = ({
       const stream = await navigator.mediaDevices.getUserMedia(constraints);
       stream.getTracks().forEach(track => track.stop());
       
-      setCameraPermissionWithLog("granted");
+      setCameraPermission("granted");
       track("daydream_camera_permission_granted", {
         is_authenticated: authenticated,
       });
       onCameraPermissionGranted();
       
-      setCurrentScreenWithLog("prompts");
+      setCurrentScreen("prompts");
       return true;
     } catch (err) {
-      setCameraPermissionWithLog("denied");
+      setCameraPermission("denied");
       track("daydream_camera_permission_denied", {
         is_authenticated: authenticated,
       });
@@ -266,7 +246,7 @@ const Interstitial: React.FC<InterstitialProps> = ({
   };
 
   const handleBack = () => {
-    setCurrentScreenWithLog("camera");
+    setCurrentScreen("camera");
   };
 
   const slideVariants = {
@@ -332,11 +312,11 @@ const Interstitial: React.FC<InterstitialProps> = ({
     if (cameraPermission !== "granted") {
       const cameraGranted = await requestCamera();
       if (cameraGranted) {
-        setCurrentScreenWithLog("prompts");
+        setCurrentScreen("prompts");
       }
     } else {
       onCameraPermissionGranted();
-      setCurrentScreenWithLog("prompts");
+      setCurrentScreen("prompts");
     }
     
     setIsPermissionLoading(false);

--- a/apps/app/components/welcome/featured/interstitial.tsx
+++ b/apps/app/components/welcome/featured/interstitial.tsx
@@ -96,7 +96,6 @@ const Interstitial: React.FC<InterstitialProps> = ({
   showLoginPrompt = false,
   showPromptSelection = false,
 }) => {
-  
   const { authenticated, login } = usePrivy();
   const [cameraPermission, setCameraPermission] =
     useState<PermissionState>("prompt");
@@ -129,7 +128,7 @@ const Interstitial: React.FC<InterstitialProps> = ({
             name: "camera" as PermissionName,
           });
           const state = permissionStatus.state as PermissionState;
-          
+
           setCameraPermission(state);
           if (state === "granted") {
             setInitialCameraGranted(true);
@@ -147,7 +146,7 @@ const Interstitial: React.FC<InterstitialProps> = ({
     };
 
     checkCamera();
-    
+
     if (cameraPermission === "granted") {
       const checkMic = async () => {
         try {
@@ -184,7 +183,7 @@ const Interstitial: React.FC<InterstitialProps> = ({
       !autoProceeded
     ) {
       const hasVisited = localStorage.getItem("hasSeenLandingPage");
-      
+
       if (hasVisited) {
         setAutoProceeded(true);
         onReady();
@@ -221,13 +220,13 @@ const Interstitial: React.FC<InterstitialProps> = ({
     try {
       const stream = await navigator.mediaDevices.getUserMedia(constraints);
       stream.getTracks().forEach(track => track.stop());
-      
+
       setCameraPermission("granted");
       track("daydream_camera_permission_granted", {
         is_authenticated: authenticated,
       });
       onCameraPermissionGranted();
-      
+
       setCurrentScreen("prompts");
       return true;
     } catch (err) {
@@ -292,10 +291,12 @@ const Interstitial: React.FC<InterstitialProps> = ({
       camera_permission: cameraPermission,
       mic_permission: micPermission,
     });
-    
+
     if (micPermission !== "granted") {
       try {
-        const audioStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        const audioStream = await navigator.mediaDevices.getUserMedia({
+          audio: true,
+        });
         audioStream.getTracks().forEach(track => track.stop());
         setMicPermission("granted");
         track("daydream_microphone_permission_granted", {
@@ -308,7 +309,7 @@ const Interstitial: React.FC<InterstitialProps> = ({
         });
       }
     }
-    
+
     if (cameraPermission !== "granted") {
       const cameraGranted = await requestCamera();
       if (cameraGranted) {
@@ -318,7 +319,7 @@ const Interstitial: React.FC<InterstitialProps> = ({
       onCameraPermissionGranted();
       setCurrentScreen("prompts");
     }
-    
+
     setIsPermissionLoading(false);
   };
 
@@ -326,9 +327,9 @@ const Interstitial: React.FC<InterstitialProps> = ({
     setIsPromptLoading(true);
     if (selectedPrompt && onPromptApply) {
       onPromptApply(selectedPrompt);
-      
+
       await new Promise(resolve => setTimeout(resolve, 2000));
-      
+
       onReady();
     }
     setIsPromptLoading(false);
@@ -372,7 +373,7 @@ const Interstitial: React.FC<InterstitialProps> = ({
       <AnimatePresence mode="wait" initial={false}>
         {currentScreen === "camera" ? (
           <Slide keyName="camera" slideVariants={slideVariants}>
-            <div 
+            <div
               className="bg-[#161616] border border-[#232323] rounded-xl p-3 sm:p-4 md:p-8 max-w-2xl w-full mx-auto shadow-lg cursor-pointer"
               onClick={handlePermissionContinue}
             >
@@ -405,8 +406,9 @@ const Interstitial: React.FC<InterstitialProps> = ({
                   </div>
                 ))}
               </div>
-              <div className="flex flex-col items-center gap-4 mt-8"
-                onClick={(e) => e.stopPropagation()}
+              <div
+                className="flex flex-col items-center gap-4 mt-8"
+                onClick={e => e.stopPropagation()}
               >
                 {(cameraPermission === "prompt" ||
                   cameraPermission === "granted") && (


### PR DESCRIPTION
This is s rework of how camera and mic permission are working

How it was before:
- Onload, check if user has given permission for camera and mic. If he hasn't, instantly prompt them. If they have already, close the interstitial

Now:
- Onload, check if the user has given permission for camera and mic. if he hasn't display the permissions modal. if the user clicks, prompts for permissions, then show the prompt selector.