### PR TITLE
feat: use Livepeer Player instead of iframe for daydream

### DIFF
--- a/apps/app/app/api/streams/delete.ts
+++ b/apps/app/app/api/streams/delete.ts
@@ -1,8 +1,7 @@
 "use server";
 
 import { createServerClient } from "@repo/supabase";
-import { Livepeer } from "livepeer";
-import { livepeer as livePeerEnv } from "@/lib/env";
+import { livepeerSDK } from "@/lib/core";
 
 export async function deleteStream(streamId: string) {
   const supabase = await createServerClient();
@@ -18,11 +17,6 @@ export async function deleteStream(streamId: string) {
 
 export const deleteLivepeerStream = async (name: string) => {
   try {
-    const livepeerSDK = new Livepeer({
-      serverURL: livePeerEnv.apiUrl,
-      apiKey: livePeerEnv.apiKey,
-    });
-
     const { error } = await livepeerSDK.stream.delete(name);
 
     return { error };

--- a/apps/app/app/api/streams/get.ts
+++ b/apps/app/app/api/streams/get.ts
@@ -94,9 +94,9 @@ export async function getStreams(
 export async function getStreamPlaybackInfo(playbackId: string) {
   try {
     const response = await livepeerSDK.playback.get(playbackId);
-    return { data: response.playbackInfo, error: null };
+    return response.playbackInfo ?? null;
   } catch (error) {
     console.error("Error fetching playback info:", error);
-    return { data: null, error: error };
+    throw new Error("Could not fetch playback info");
   }
 }

--- a/apps/app/app/api/streams/get.ts
+++ b/apps/app/app/api/streams/get.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { livepeerSDK } from "@/lib/core";
 import { createServerClient } from "@repo/supabase";
 
 export async function getStream(streamId: string) {
@@ -88,4 +89,14 @@ export async function getStreams(
     data,
     totalPages,
   };
+}
+
+export async function getStreamPlaybackInfo(playbackId: string) {
+  try {
+    const response = await livepeerSDK.playback.get(playbackId);
+    return { data: response.playbackInfo, error: null };
+  } catch (error) {
+    console.error("Error fetching playback info:", error);
+    return { data: null, error: error };
+  }
 }

--- a/apps/app/app/api/streams/upsert.ts
+++ b/apps/app/app/api/streams/upsert.ts
@@ -2,9 +2,9 @@
 
 import { createServerClient } from "@repo/supabase";
 import { z } from "zod";
-import { Livepeer } from "livepeer";
 import { newId } from "@/lib/generate-id";
 import { livepeer as livePeerEnv } from "@/lib/env";
+import { livepeerSDK } from "@/lib/core";
 
 const streamSchema = z
   .object({
@@ -115,11 +115,6 @@ export async function upsertStream(body: any, userId: string) {
 
 export const createLivepeerStream = async (name?: string) => {
   try {
-    const livepeerSDK = new Livepeer({
-      serverURL: livePeerEnv.apiUrl,
-      apiKey: livePeerEnv.apiKey,
-    });
-
     const { stream, error } = await livepeerSDK.stream.create({
       name: name || "stream",
     });

--- a/apps/app/components/playground/broadcast.tsx
+++ b/apps/app/components/playground/broadcast.tsx
@@ -32,11 +32,13 @@ export function BroadcastWithControls({
   className,
   onCollapse,
   isCollapsed,
+  audio = false,
 }: {
   ingestUrl: string | null;
   className?: string;
   onCollapse?: (collapsed: boolean) => void;
   isCollapsed?: boolean;
+  audio?: boolean;
 }) {
   const [isPiP, setIsPiP] = useState(false);
   const videoId = "live-video";
@@ -85,7 +87,7 @@ export function BroadcastWithControls({
       }
       forceEnabled={true}
       noIceGathering={true}
-      audio={false}
+      audio={audio}
       aspectRatio={16 / 9}
       ingestUrl={ingestUrl}
     >

--- a/apps/app/components/welcome/featured/dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/dreamshaper.tsx
@@ -400,6 +400,7 @@ export default function Dreamshaper({
                     isCollapsed={isCollapsed}
                     onCollapse={setIsCollapsed}
                     className="rounded-xl overflow-hidden"
+                    audio={false}
                   />
                 </div>
               )}
@@ -634,10 +635,7 @@ export default function Dreamshaper({
       )}
 
       {streamId && (
-        <StreamInfo 
-          streamId={streamId} 
-          isFullscreen={isFullscreen}
-        />
+        <StreamInfo streamId={streamId} isFullscreen={isFullscreen} />
       )}
     </div>
   );

--- a/apps/app/components/welcome/featured/dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/dreamshaper.tsx
@@ -384,6 +384,7 @@ export default function Dreamshaper({
                 <LivepeerPlayer
                   output_playback_id={outputPlaybackId}
                   isMobile={isMobile}
+                  stream_key={streamKey}
                 />
                 {/* Overlay */}
                 <div className="absolute inset-x-0 top-0 h-[85%] bg-transparent" />

--- a/apps/app/components/welcome/featured/dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/dreamshaper.tsx
@@ -29,6 +29,7 @@ import { StreamDebugPanel } from "@/components/stream/stream-debug-panel";
 import { StreamStatus } from "@/hooks/useStreamStatus";
 import { TrackedButton } from "@/components/analytics/TrackedButton";
 import { StreamInfo } from "@/components/footer/stream-info";
+import { LivepeerPlayer } from "./player";
 
 const PROMPT_INTERVAL = 4000;
 const samplePrompts = examplePrompts.map(prompt => prompt.prompt);
@@ -380,9 +381,8 @@ export default function Dreamshaper({
           ) : outputPlaybackId ? (
             <>
               <div className="relative w-full h-full">
-                <LPPLayer
+                <LivepeerPlayer
                   output_playback_id={outputPlaybackId}
-                  stream_key={streamKey}
                   isMobile={isMobile}
                 />
                 {/* Overlay */}
@@ -404,16 +404,6 @@ export default function Dreamshaper({
                   />
                 </div>
               )}
-              {!live || showOverlay ? (
-                <div className="absolute inset-0 bg-black flex flex-col items-center justify-center rounded-2xl">
-                  <Loader2 className="h-8 w-8 animate-spin text-white" />
-                  {statusMessage && (
-                    <span className="mt-4 text-white text-sm">
-                      {statusMessage}
-                    </span>
-                  )}
-                </div>
-              ) : null}
             </>
           ) : (
             <div className="w-full h-full flex items-center justify-center text-muted-foreground">

--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -34,10 +34,12 @@ export const LivepeerPlayer = React.memo(
 
     if (!src) {
       return (
-        <PlayerLoading
-          title="Stream is not available"
-          description="Please try refreshing the page in a few seconds."
-        />
+        <div className="w-full relative h-full bg-black/50 backdrop-blur data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0">
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+            <LoadingIcon className="w-8 h-8 animate-spin" />
+          </div>
+          <PlayerLoading />
+        </div>
       );
     }
 
@@ -49,7 +51,7 @@ export const LivepeerPlayer = React.memo(
           clipLength={30}
           src={src}
           jwt={null}
-          backoffMax={10000}
+          backoffMax={1000}
           timeout={90000}
           lowLatency="force"
         >
@@ -79,13 +81,10 @@ export const LivepeerPlayer = React.memo(
             matcher="offline"
             className="absolute select-none animate-in fade-in-0 inset-0 text-center bg-black/80 backdrop-blur-lg flex flex-col items-center justify-center gap-4 duration-1000 data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0"
           >
-            <OfflineErrorIcon className="h-[120px] w-full sm:flex hidden" />
-            <div className="flex flex-col gap-1">
-              <div className="text-2xl font-bold">Stream is offline</div>
-              <div className="text-sm text-gray-100">
-                Playback will start automatically once the stream has started
-              </div>
-            </div>
+            <PlayerLoading
+              title="ALMOST THERE"
+              description="Please wait while we are rendering your stream"
+            />
           </Player.ErrorIndicator>
 
           <Player.ErrorIndicator

--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -34,6 +34,9 @@ export const LivepeerPlayer = React.memo(
     const debugMode = searchParams.get("debugMode") === "true";
 
     useEffect(() => {
+      if (useMediamtx) {
+        return;
+      }
       const fetchPlaybackInfo = async () => {
         const info = await getStreamPlaybackInfo(output_playback_id);
         setPlaybackInfo(info);

--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import * as React from "react";
+import { getStreamPlaybackInfo } from "@/app/api/streams/get";
+import {
+  PrivateErrorIcon,
+  OfflineErrorIcon,
+  LoadingIcon,
+} from "@livepeer/react/assets";
+import { getSrc } from "@livepeer/react/external";
+import * as Player from "@livepeer/react/player";
+import { PlaybackInfo } from "livepeer/models/components";
+import { useEffect, useState } from "react";
+
+export const LivepeerPlayer = React.memo(
+  ({
+    output_playback_id,
+    isMobile,
+  }: {
+    output_playback_id: string;
+    isMobile?: boolean;
+  }) => {
+    const [playbackInfo, setPlaybackInfo] = useState<PlaybackInfo | null>(null);
+
+    useEffect(() => {
+      const fetchPlaybackInfo = async () => {
+        const info = await getStreamPlaybackInfo(output_playback_id);
+        setPlaybackInfo(info);
+      };
+      fetchPlaybackInfo();
+    }, [output_playback_id]);
+
+    const src = getSrc(playbackInfo);
+
+    if (!src) {
+      return (
+        <PlayerLoading
+          title="Stream is not available"
+          description="Please try refreshing the page in a few seconds."
+        />
+      );
+    }
+
+    return (
+      <div className={isMobile ? "w-full h-full" : "aspect-video"}>
+        <Player.Root
+          autoPlay
+          aspectRatio={16 / 9}
+          clipLength={30}
+          src={src}
+          jwt={null}
+          backoffMax={10000}
+          timeout={90000}
+          lowLatency="force"
+        >
+          <Player.Video
+            title="Live stream"
+            className="h-full w-full transition-all object-contain"
+          />
+
+          <Player.LoadingIndicator className="w-full relative h-full bg-black/50 backdrop-blur data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0">
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+              <LoadingIcon className="w-8 h-8 animate-spin" />
+            </div>
+            <PlayerLoading />
+          </Player.LoadingIndicator>
+
+          <Player.ErrorIndicator
+            matcher="all"
+            className="absolute select-none inset-0 text-center bg-black/80 backdrop-blur-lg flex flex-col items-center justify-center gap-4 duration-1000 data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0"
+          >
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+              <LoadingIcon className="w-8 h-8 animate-spin" />
+            </div>
+            <PlayerLoading />
+          </Player.ErrorIndicator>
+
+          <Player.ErrorIndicator
+            matcher="offline"
+            className="absolute select-none animate-in fade-in-0 inset-0 text-center bg-black/80 backdrop-blur-lg flex flex-col items-center justify-center gap-4 duration-1000 data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0"
+          >
+            <OfflineErrorIcon className="h-[120px] w-full sm:flex hidden" />
+            <div className="flex flex-col gap-1">
+              <div className="text-2xl font-bold">Stream is offline</div>
+              <div className="text-sm text-gray-100">
+                Playback will start automatically once the stream has started
+              </div>
+            </div>
+          </Player.ErrorIndicator>
+
+          <Player.ErrorIndicator
+            matcher="access-control"
+            className="absolute select-none inset-0 text-center bg-black/80 backdrop-blur-lg flex flex-col items-center justify-center gap-4 duration-1000 data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0"
+          >
+            <PrivateErrorIcon className="h-[120px] w-full sm:flex hidden" />
+            <div className="flex flex-col gap-1">
+              <div className="text-2xl font-bold">Stream is private</div>
+              <div className="text-sm text-gray-100">
+                It looks like you don't have permission to view this content
+              </div>
+            </div>
+          </Player.ErrorIndicator>
+        </Player.Root>
+      </div>
+    );
+  },
+);
+
+export const PlayerLoading = ({
+  title,
+  description,
+}: {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+}) => (
+  <div className="relative w-full px-3 py-2 gap-3 flex-col-reverse flex aspect-video bg-white/10 overflow-hidden rounded-sm">
+    <div className="flex justify-between">
+      <div className="flex items-center gap-2">
+        <div className="w-6 h-6 animate-pulse bg-white/5 overflow-hidden rounded-lg" />
+        <div className="w-16 h-6 md:w-20 md:h-7 animate-pulse bg-white/5 overflow-hidden rounded-lg" />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="w-6 h-6 animate-pulse bg-white/5 overflow-hidden rounded-lg" />
+        <div className="w-6 h-6 animate-pulse bg-white/5 overflow-hidden rounded-lg" />
+      </div>
+    </div>
+    <div className="w-full h-2 animate-pulse bg-white/5 overflow-hidden rounded-lg" />
+
+    {title && (
+      <div className="absolute flex flex-col gap-1 inset-10 text-center justify-center items-center">
+        <span className="text-white text-lg font-medium">{title}</span>
+        {description && (
+          <span className="text-sm text-white/80">{description}</span>
+        )}
+      </div>
+    )}
+  </div>
+);

--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -6,6 +6,11 @@ import {
   PrivateErrorIcon,
   OfflineErrorIcon,
   LoadingIcon,
+  EnterFullscreenIcon,
+  ExitFullscreenIcon,
+  PictureInPictureIcon,
+  UnmuteIcon,
+  MuteIcon,
 } from "@livepeer/react/assets";
 import { getSrc } from "@livepeer/react/external";
 import * as Player from "@livepeer/react/player";
@@ -13,6 +18,7 @@ import { PlaybackInfo } from "livepeer/models/components";
 import { useEffect, useRef, useState } from "react";
 import { isProduction } from "@/lib/env";
 import { useSearchParams } from "next/navigation";
+import { PauseIcon, PlayIcon, Settings } from "lucide-react";
 
 export const LivepeerPlayer = React.memo(
   ({
@@ -114,6 +120,44 @@ export const LivepeerPlayer = React.memo(
             </div>
           </Player.ErrorIndicator>
           {debugMode && <DebugTimer />}
+
+          <Player.Controls
+            autoHide={1000}
+            className="bg-gradient-to-b gap-1 px-3 md:px-3 py-2 flex-col-reverse flex from-black/20 via-80% via-black/30 duration-1000 to-black/60 data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0"
+          >
+            <div className="flex justify-between gap-4">
+              <div className="flex flex-1 items-center gap-3">
+                <Player.PlayPauseTrigger className="w-6 h-6 hover:scale-110 transition-all flex-shrink-0">
+                  <Player.PlayingIndicator asChild matcher={false}>
+                    <PlayIcon className="w-full h-full" />
+                  </Player.PlayingIndicator>
+                  <Player.PlayingIndicator asChild>
+                    <PauseIcon className="w-full h-full" />
+                  </Player.PlayingIndicator>
+                </Player.PlayPauseTrigger>
+
+                <Player.MuteTrigger className="w-6 h-6 hover:scale-110 transition-all flex-shrink-0">
+                  <Player.VolumeIndicator asChild matcher={false}>
+                    <MuteIcon className="w-full h-full" />
+                  </Player.VolumeIndicator>
+                  <Player.VolumeIndicator asChild matcher={true}>
+                    <UnmuteIcon className="w-full h-full" />
+                  </Player.VolumeIndicator>
+                </Player.MuteTrigger>
+                <Player.Volume className="relative mr-1 flex-1 group flex cursor-pointer items-center select-none touch-none max-w-[120px] h-5">
+                  <Player.Track className="bg-white/30 relative grow rounded-full transition-all h-[2px] md:h-[3px] group-hover:h-[3px] group-hover:md:h-[4px]">
+                    <Player.Range className="absolute bg-white rounded-full h-full" />
+                  </Player.Track>
+                  <Player.Thumb className="block transition-all group-hover:scale-110 w-3 h-3 bg-white rounded-full" />
+                </Player.Volume>
+              </div>
+              <div className="flex sm:flex-1 md:flex-[1.5] justify-end items-center gap-2.5">
+                <Player.PictureInPictureTrigger className="w-6 h-6 hover:scale-110 transition-all flex-shrink-0">
+                  <PictureInPictureIcon className="w-full h-full" />
+                </Player.PictureInPictureTrigger>
+              </div>
+            </div>
+          </Player.Controls>
         </Player.Root>
       </div>
     );
@@ -168,7 +212,7 @@ const DebugTimer = ({ __scopeMedia }: Player.MediaScopedProps) => {
   }, [state.hasPlayed]);
 
   return firstFrameTime ? (
-    <div className="absolute bottom-4 left-2 flex items-center gap-1">
+    <div className="absolute bottom-12 left-4 flex items-center gap-1">
       <p className="text-xs text-white/50">First Frame Loaded in:</p>
       <div className="w-2 h-2 rounded-full bg-blue-400 animate-pulse" />
       <span className="text-xs text-blue-400">

--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -22,7 +22,7 @@ export const LivepeerPlayer = React.memo(
   }: {
     output_playback_id: string;
     isMobile?: boolean;
-    stream_key?: string;
+    stream_key?: string | null;
   }) => {
     const [playbackInfo, setPlaybackInfo] = useState<PlaybackInfo | null>(null);
     const playerUrl = `https://ai.livepeer.${isProduction() ? "com" : "monster"}/aiWebrtc/${stream_key}-out`;

--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -11,16 +11,24 @@ import { getSrc } from "@livepeer/react/external";
 import * as Player from "@livepeer/react/player";
 import { PlaybackInfo } from "livepeer/models/components";
 import { useEffect, useState } from "react";
+import { isProduction } from "@/lib/env";
+import { useSearchParams } from "next/navigation";
 
 export const LivepeerPlayer = React.memo(
   ({
     output_playback_id,
     isMobile,
+    stream_key,
   }: {
     output_playback_id: string;
     isMobile?: boolean;
+    stream_key?: string;
   }) => {
     const [playbackInfo, setPlaybackInfo] = useState<PlaybackInfo | null>(null);
+    const playerUrl = `https://ai.livepeer.${isProduction() ? "com" : "monster"}/aiWebrtc/${stream_key}-out`;
+
+    const searchParams = useSearchParams();
+    const useMediamtx = searchParams.get("useMediamtx") === "true";
 
     useEffect(() => {
       const fetchPlaybackInfo = async () => {
@@ -30,7 +38,7 @@ export const LivepeerPlayer = React.memo(
       fetchPlaybackInfo();
     }, [output_playback_id]);
 
-    const src = getSrc(playbackInfo);
+    const src = getSrc(useMediamtx ? playerUrl : playbackInfo);
 
     if (!src) {
       return (
@@ -99,11 +107,20 @@ export const LivepeerPlayer = React.memo(
               </div>
             </div>
           </Player.ErrorIndicator>
+          <StateRenderer />
         </Player.Root>
       </div>
     );
   },
 );
+
+const StateRenderer = ({ __scopeMedia }: Player.MediaScopedProps) => {
+  const context = Player.useMediaContext("CustomComponent", __scopeMedia);
+
+  const state = Player.useStore(context.store);
+  console.log("LivepeerPlayer:: State", state);
+  return null;
+};
 
 export const PlayerLoading = ({
   title,

--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -226,7 +226,7 @@ const DebugTimer = ({
         is_authenticated: authenticated,
       });
     }
-  }, [firstFrameTime]);
+  }, [firstFrameTime, authenticated]);
 
   if (!firstFrameTime || !debugMode) {
     return null;

--- a/apps/app/lib/core.ts
+++ b/apps/app/lib/core.ts
@@ -1,0 +1,7 @@
+import { Livepeer } from "livepeer";
+import { livepeer as livePeerEnv } from "./env";
+
+export const livepeerSDK = new Livepeer({
+  serverURL: livePeerEnv.apiUrl,
+  apiKey: livePeerEnv.apiKey,
+});


### PR DESCRIPTION
Uses the Livepeer Player component to render the playback.

- Supports mediamtx playback by default
- Support livepeer tv playback: Set the env variable `NEXT_PUBLIC_LIVEPEER_DIRECT_PLAYBACK=true` and rebuild
- Add logic to track Time-To-First-Frame: add `debugMode=true` to query params to view this
Ex: https://pipelines-gd548c8e2-livepeer.vercel.app/?debugMode=true
- Added tracking event `stream_first_frame_loaded` to track the time taken to load first frame

