### PR TITLE
daydream: fix: stream creation render

### DIFF
--- a/apps/app/components/welcome/featured/useDreamshaper.tsx
+++ b/apps/app/components/welcome/featured/useDreamshaper.tsx
@@ -87,7 +87,7 @@ const extractCommands = (promptText: string) => {
 };
 
 export function useDreamshaper() {
-  const { user } = usePrivy();
+  const { user, ready } = usePrivy();
   const searchParams = useSearchParams();
   const pathname = usePathname();
 
@@ -261,6 +261,8 @@ export function useDreamshaper() {
   ]);
 
   useEffect(() => {
+    if (!ready) return;
+    
     let isMounted = true;
 
     const fetchData = async () => {
@@ -305,7 +307,7 @@ export function useDreamshaper() {
     return () => {
       isMounted = false;
     };
-  }, [pathname, user]);
+  }, [pathname, ready, user]);
 
   const handleUpdate = useCallback(
     async (prompt: string, options?: UpdateOptions) => {


### PR DESCRIPTION
So, what is happening is that the page load before the privy auth completes, so it creates a stream with the default infraservice user
But then, when privy completes, the user get updated and since user is in the dependencies of the stream creation, another stream gets created 

This causes instabilities sometimes with the status fetch, since depending on DB speed it's fetching the previous stream, and it's also sometime broadcasting on the first stream for a while before privy gets ready

This addresses the issue, waiting for the privy ready state to be true before doing any action