### PR TITLE
Append (((clothed))) to all prompts to avoid accidental NSFW

### DIFF
--- a/apps/app/components/daydream/index.tsx
+++ b/apps/app/components/daydream/index.tsx
@@ -102,7 +102,7 @@ export default function DayDreamContent(): ReactElement {
   };
 
   const handlePromptApply = (prompt: string) => {
-    setPendingPrompt(prompt);
+    setPendingPrompt(prompt + " ((clothed))");
     localStorage.setItem("hasSelectedPrompt", "true");
   };
 

--- a/apps/app/components/daydream/index.tsx
+++ b/apps/app/components/daydream/index.tsx
@@ -102,7 +102,7 @@ export default function DayDreamContent(): ReactElement {
   };
 
   const handlePromptApply = (prompt: string) => {
-    setPendingPrompt(prompt + " ((clothed))");
+    setPendingPrompt(prompt);
     localStorage.setItem("hasSelectedPrompt", "true");
   };
 

--- a/apps/app/components/welcome/featured/dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/dreamshaper.tsx
@@ -327,7 +327,7 @@ export default function Dreamshaper({
       });
 
       // Prevent accidental NSFW images
-      const inputValueSFW = inputValue + " ((clothed))";
+      const inputValueSFW = inputValue + " (((clothed)))";
 
       handleUpdate(inputValueSFW, { silent: true });
       setLastSubmittedPrompt(inputValue); // Store the submitted prompt

--- a/apps/app/components/welcome/featured/dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/dreamshaper.tsx
@@ -326,7 +326,10 @@ export default function Dreamshaper({
         stream_id: streamId,
       });
 
-      handleUpdate(inputValue, { silent: true });
+      // Prevent accidental NSFW images
+      const inputValueSFW = inputValue + " ((clothed))";
+
+      handleUpdate(inputValueSFW, { silent: true });
       setLastSubmittedPrompt(inputValue); // Store the submitted prompt
       setHasSubmittedPrompt(true);
       setInputValue("");


### PR DESCRIPTION
This appends to the prompt before sending to the backend (i.e in a way that's never visible to the user).

The intent is to avoid accidental flashes of NSFW content rather than blocking people deliberately trying to create that content.

We found that the negative prompt didn't have enough of an effect to be helpful here.