### PR TITLE
fix: dd: single broadcast player component

### DIFF
--- a/apps/app/components/welcome/featured/ManagedBroadcast.tsx
+++ b/apps/app/components/welcome/featured/ManagedBroadcast.tsx
@@ -4,10 +4,10 @@ import { useEffect, useRef, useState } from "react";
 import { BroadcastWithControls } from "@/components/playground/broadcast";
 import { Loader2 } from "lucide-react";
 import { cn } from "@repo/design-system/lib/utils";
+import { useIsMobile } from "@repo/design-system/hooks/use-mobile";
 
 interface ManagedBroadcastProps {
   streamUrl: string | null;
-  isMobile: boolean;
   isFullscreen: boolean;
   outputPlayerRef: React.RefObject<HTMLDivElement>;
   loading?: boolean;
@@ -15,24 +15,28 @@ interface ManagedBroadcastProps {
 
 export function ManagedBroadcast({
   streamUrl,
-  isMobile,
   isFullscreen,
   outputPlayerRef,
   loading = false
 }: ManagedBroadcastProps) {
+  const isMobile = useIsMobile();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [playerPosition, setPlayerPosition] = useState({ bottom: 0, right: 0 });
 
   useEffect(() => {
     if (!isMobile && outputPlayerRef.current) {
       const updatePlayerPosition = () => {
-        const rect = outputPlayerRef.current?.getBoundingClientRect();
-        if (rect) {
-          setPlayerPosition({
-            bottom: rect.bottom,
-            right: rect.right
-          });
-        }
+        if (!outputPlayerRef.current) return;
+        const rect = outputPlayerRef.current.getBoundingClientRect();
+        const newBottom = rect.bottom;
+        const newRight = rect.right;
+        
+        setPlayerPosition(prev => {
+          if (prev.bottom === newBottom && prev.right === newRight) {
+            return prev;
+          }
+          return { bottom: newBottom, right: newRight };
+        });
       };
       
       updatePlayerPosition();

--- a/apps/app/components/welcome/featured/ManagedBroadcast.tsx
+++ b/apps/app/components/welcome/featured/ManagedBroadcast.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { BroadcastWithControls } from "@/components/playground/broadcast";
+import { Loader2 } from "lucide-react";
+import { cn } from "@repo/design-system/lib/utils";
+
+interface ManagedBroadcastProps {
+  streamUrl: string | null;
+  isMobile: boolean;
+  isFullscreen: boolean;
+  outputPlayerRef: React.RefObject<HTMLDivElement>;
+  loading?: boolean;
+}
+
+export function ManagedBroadcast({
+  streamUrl,
+  isMobile,
+  isFullscreen,
+  outputPlayerRef,
+  loading = false
+}: ManagedBroadcastProps) {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [playerPosition, setPlayerPosition] = useState({ bottom: 0, right: 0 });
+
+  useEffect(() => {
+    if (!isMobile && outputPlayerRef.current) {
+      const updatePlayerPosition = () => {
+        const rect = outputPlayerRef.current?.getBoundingClientRect();
+        if (rect) {
+          setPlayerPosition({
+            bottom: rect.bottom,
+            right: rect.right
+          });
+        }
+      };
+      
+      updatePlayerPosition();
+      
+      window.addEventListener('resize', updatePlayerPosition);
+      window.addEventListener('scroll', updatePlayerPosition);
+      
+      const resizeObserver = new ResizeObserver(() => {
+        updatePlayerPosition();
+      });
+      
+      resizeObserver.observe(outputPlayerRef.current);
+      
+      return () => {
+        window.removeEventListener('resize', updatePlayerPosition);
+        window.removeEventListener('scroll', updatePlayerPosition);
+        resizeObserver.disconnect();
+      };
+    }
+  }, [isMobile, outputPlayerRef]);
+
+  useEffect(() => {
+    setIsCollapsed(isMobile);
+  }, [isMobile]);
+
+  if (!streamUrl) return null;
+
+  return (
+    <div 
+      className={cn(
+        "transition-all duration-100",
+        isMobile 
+          ? "mx-4 w-auto -mt-2 mb-4" 
+          : "absolute z-50" 
+      )}
+      style={!isMobile ? {
+        position: "fixed",
+        bottom: isFullscreen 
+          ? "80px" 
+          : `${window.innerHeight - playerPosition.bottom + 40}px`,
+        right: isFullscreen 
+          ? "16px" 
+          : `${window.innerWidth - playerPosition.right + 20}px`,
+        width: isCollapsed ? "48px" : "250px",
+        height: isCollapsed ? "48px" : "auto",
+        aspectRatio: isCollapsed ? "1" : "16/9",
+        boxShadow: "0 4px 12px rgba(0, 0, 0, 0.15)",
+        transform: "translate(0, 0)",
+      } : {}}
+    >
+      {loading && isMobile ? (
+        <div className="w-8 h-8 flex items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <div
+          className={cn(
+            "transition-all duration-300",
+            isMobile 
+              ? cn(
+                  "flex-shrink-0 [&>div]:!pb-0 [&>div]:h-full",
+                  isCollapsed ? "h-8" : "h-64"
+                )
+              : cn(
+                  "rounded-xl overflow-hidden", 
+                  isCollapsed ? "w-12 h-12" : "w-full aspect-video"
+                )
+          )}
+        >
+          <BroadcastWithControls
+            ingestUrl={streamUrl}
+            isCollapsed={isCollapsed}
+            onCollapse={setIsCollapsed}
+            className={cn(
+              "rounded-xl overflow-hidden",
+              isMobile ? "w-full h-full" : ""
+            )}
+          />
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/apps/app/components/welcome/featured/dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/dreamshaper.tsx
@@ -41,6 +41,7 @@ import { ShareModal } from "./ShareModal";
 import { UpdateOptions } from "./useDreamshaper";
 import { MAX_PROMPT_LENGTH, useValidateInput } from "./useValidateInput";
 import { ClipButton } from "@/components/ClipButton";
+import { ManagedBroadcast } from "./ManagedBroadcast";
 
 const PROMPT_PLACEHOLDER = "Describe the style to transform your stream...";
 
@@ -650,21 +651,6 @@ export default function Dreamshaper({
                 {/* Overlay */}
                 <div className="absolute inset-x-0 top-0 h-[85%] bg-transparent" />
               </div>
-              {!isMobile && streamUrl && (
-                <div
-                  className={cn(
-                    "absolute bottom-16 right-4 z-50 transition-all duration-300",
-                    isCollapsed ? "w-12 h-12" : "w-[25%] aspect-video",
-                  )}
-                >
-                  <BroadcastWithControls
-                    ingestUrl={streamUrl}
-                    isCollapsed={isCollapsed}
-                    onCollapse={setIsCollapsed}
-                    className="rounded-xl overflow-hidden"
-                  />
-                </div>
-              )}
               {!live || showOverlay ? (
                 <div className="absolute inset-0 bg-black flex flex-col items-center justify-center rounded-2xl">
                   <Loader2 className="h-8 w-8 animate-spin text-white" />
@@ -684,30 +670,13 @@ export default function Dreamshaper({
         </div>
       </div>
 
-      {/* Mobile broadcast controls */}
-      {isMobile && streamUrl && (
-        <div className="mx-4 w-auto -mt-2 mb-4">
-          {loading ? (
-            <div className="w-8 h-8 flex items-center justify-center">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            </div>
-          ) : (
-            <div
-              className={cn(
-                "flex-shrink-0 transition-all duration-300 [&>div]:!pb-0 [&>div]:h-full",
-                isCollapsed ? "h-8" : "h-64",
-              )}
-            >
-              <BroadcastWithControls
-                ingestUrl={streamUrl}
-                isCollapsed={isCollapsed}
-                onCollapse={setIsCollapsed}
-                className="rounded-xl overflow-hidden w-full h-full"
-              />
-            </div>
-          )}
-        </div>
-      )}
+      <ManagedBroadcast
+        streamUrl={streamUrl}
+        isMobile={isMobile}
+        isFullscreen={isFullscreen}
+        outputPlayerRef={outputPlayerRef}
+        loading={loading}
+      />
 
       {/* Input prompt */}
       <div

--- a/apps/app/components/welcome/featured/dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/dreamshaper.tsx
@@ -672,7 +672,6 @@ export default function Dreamshaper({
 
       <ManagedBroadcast
         streamUrl={streamUrl}
-        isMobile={isMobile}
         isFullscreen={isFullscreen}
         outputPlayerRef={outputPlayerRef}
         loading={loading}


### PR DESCRIPTION
So, this was kind of a mess

Mobile and desktop were using 2 separate broadcast components, and this was causing reconnection issues, because on resize under 768px of width, it would destroy the currently running broadcast and recreate it, effectively interrupting the stream and freezing the app

This was also affecting mobile landscape mode, as broadcast recreation was interrupting the stream in that case too

What I did is:
- Unify the broadcasts to use a single component
- Make sure styling is correct for both mobile and desktop - had some hard time here because on desktop the broadcast was living with the output player as parent and on mobile was living outside of it, so I needed to reposition the broadcast correctly on desktop
- Move everything in a separate component for clarity

This should fix several reconnection issues - even the ones where you open the inspect console and you see the video freezing out