### PR TITLE
docs: replace temporary Discord invite URL with permanent URL

### DIFF
--- a/apps/app/components/header/index.tsx
+++ b/apps/app/components/header/index.tsx
@@ -26,7 +26,7 @@ export default function Header() {
     {
       label: "Community",
       external: true,
-      href: "https://discord.com/invite/hxyNHeSzCK",
+      href: "https://discord.gg/livepeer",
     },
   ];
 

--- a/apps/app/components/modals/trial-expired-modal.tsx
+++ b/apps/app/components/modals/trial-expired-modal.tsx
@@ -40,7 +40,7 @@ export function TrialExpiredModal({
               location: "trial_expired_modal",
             }}
             onClick={() =>
-              window.open("https://discord.com/invite/hxyNHeSzCK", "_blank")
+              window.open("https://discord.gg/livepeer", "_blank")
             }
             size="lg"
             className="rounded-full h-12 flex-1 bg-black text-white hover:bg-black/90"

--- a/apps/app/components/sidebar.tsx
+++ b/apps/app/components/sidebar.tsx
@@ -135,7 +135,7 @@ export const GlobalSidebar = ({ children }: GlobalSidebarProperties) => {
     footer: [
       {
         title: "Join Community",
-        url: "https://discord.com/invite/hxyNHeSzCK",
+        url: "https://discord.gg/livepeer",
         external: true,
         icon: DiscordLogoIcon,
       },

--- a/apps/app/components/welcome/featured/dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/dreamshaper.tsx
@@ -541,7 +541,7 @@ export default function Dreamshaper({
 
             <Link
               target="_blank"
-              href="https://discord.com/invite/hxyNHeSzCK"
+              href="https://discord.gg/livepeer"
               className="bg-transparent hover:bg-black/10 border border-muted-foreground/30 text-foreground px-3 py-1 text-xs rounded-lg font-semibold h-[36px] flex items-center"
             >
               Join Community

--- a/apps/app/components/welcome/featured/index.tsx
+++ b/apps/app/components/welcome/featured/index.tsx
@@ -69,7 +69,7 @@ export default function Winners() {
         </div>
         <div>
           <Link
-            href={"https://discord.com/invite/hxyNHeSzCK"}
+            href={"https://discord.gg/livepeer"}
             target="_blank"
             className="text-sm gap-1 flex items-center -ml-20 -mt-8 md:-ml-0 md:-mt-0"
           >

--- a/apps/app/components/welcome/index.tsx
+++ b/apps/app/components/welcome/index.tsx
@@ -184,7 +184,7 @@ const MyStats = () => {
 const CTA = () => {
   return (
     <Link
-      href={"https://discord.com/invite/hxyNHeSzCK"}
+      href={"https://discord.gg/livepeer"}
       target="_blank"
       style={{
         backgroundImage:

--- a/apps/docs/knowledge-base/get-started/try-a-pipeline.mdx
+++ b/apps/docs/knowledge-base/get-started/try-a-pipeline.mdx
@@ -72,6 +72,6 @@ You may also encounter X:Y coordinate selection.
 
 ## Additional Resources
 
-- Use the [Support](https://discord.com/invite/livepeer) section for technical assistance
+- Use the [Support](https://discord.gg/livepeer) section for technical assistance
 - Provide [Feedback](https://livepeer.notion.site/15f0a348568781aab037c863d91b05e2) for feature requests or issues
 - Explore other pipelines through the ["Explore Pipelines"](https://pipelines.livepeer.org/explore) section


### PR DESCRIPTION
This pull request updates the Discord invite URL from a temporary (expiring) link to a fixed (permanent) one to ensure long-term accessibility.
