### PR TITLE
chore: update Discord invite link to a trackable one

### DIFF
--- a/apps/docs/knowledge-base/get-started/try-a-pipeline.mdx
+++ b/apps/docs/knowledge-base/get-started/try-a-pipeline.mdx
@@ -72,6 +72,6 @@ You may also encounter X:Y coordinate selection.
 
 ## Additional Resources
 
-- Use the [Support](https://discord.com/invite/livepeer) section for technical assistance
+- Use the [Support](https://discord.com/invite/hxyNHeSzCK) section for technical assistance
 - Provide [Feedback](https://livepeer.notion.site/15f0a348568781aab037c863d91b05e2) for feature requests or issues
 - Explore other pipelines through the ["Explore Pipelines"](https://pipelines.livepeer.org/explore) section


### PR DESCRIPTION
This pull request updates the general Livepeer invite link on the `try-a-pipeline` page to a trackable, permanent link. This ensures we can track traffic originating from the pipelines app.
