### PR TITLE
chore: fix oauth redirect issue

### DIFF
--- a/apps/app/app/page.tsx
+++ b/apps/app/app/page.tsx
@@ -33,9 +33,16 @@ export const generateMetadata = async ({
 export default function HomePage({
   searchParams,
 }: {
-  searchParams: { shared: string };
+  searchParams: { shared: string; privy_oauth_code: string };
 }) {
-  const { shared } = searchParams;
+  const { shared, privy_oauth_code } = searchParams;
 
-  return <Daydream hasSharedPrompt={!!shared} />;
+  return (
+    <Daydream
+      hasSharedPrompt={!!shared}
+      isOAuthSuccessRedirect={
+        privy_oauth_code?.length > 0 && privy_oauth_code !== "error"
+      }
+    />
+  );
 }

--- a/apps/app/components/daydream/LoginScreen/AuthContext.tsx
+++ b/apps/app/components/daydream/LoginScreen/AuthContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useMemo } from "react";
+import {
+  OAuthFlowState,
+  OAuthProviderType,
+  useLoginWithEmail,
+  useLoginWithOAuth,
+} from "@privy-io/react-auth";
+
+export const AuthContext = createContext<{
+  sendCode: ({ email }: { email: string }) => Promise<void>;
+  oAuthState: OAuthFlowState;
+  initOAuth: ({ provider }: { provider: OAuthProviderType }) => Promise<void>;
+}>({
+  sendCode: async () => {},
+  oAuthState: {
+    status: "initial",
+  },
+  initOAuth: async () => {},
+});
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const { sendCode } = useLoginWithEmail();
+  const { state, initOAuth } = useLoginWithOAuth();
+  const value = useMemo(
+    () => ({ sendCode, oAuthState: state, initOAuth }),
+    [sendCode, state, initOAuth],
+  );
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+};

--- a/apps/app/components/daydream/LoginScreen/DiscordLoginButton.tsx
+++ b/apps/app/components/daydream/LoginScreen/DiscordLoginButton.tsx
@@ -1,4 +1,5 @@
 import { useLoginWithOAuth } from "@privy-io/react-auth";
+import { useAuth } from "./AuthContext";
 
 function DiscordIcon() {
   return (
@@ -21,7 +22,7 @@ function DiscordIcon() {
 }
 
 export default function DiscordLoginButton() {
-  const { state, loading, initOAuth } = useLoginWithOAuth();
+  const { initOAuth, oAuthState } = useAuth();
 
   const handleLogin = async () => {
     await initOAuth({ provider: "discord" });
@@ -31,7 +32,7 @@ export default function DiscordLoginButton() {
     <button
       className="flex items-center justify-center h-9 gap-2 py-2.5 px-4 w-1/2 border border-[#E4E4E7] rounded-[6px] bg-white"
       onClick={handleLogin}
-      disabled={loading}
+      disabled={oAuthState.status === "loading"}
     >
       <DiscordIcon />
       <span className="text-[14px] font-inter font-medium text-[#09090B]">

--- a/apps/app/components/daydream/LoginScreen/EmailLoginButton.tsx
+++ b/apps/app/components/daydream/LoginScreen/EmailLoginButton.tsx
@@ -5,13 +5,14 @@ import {
 } from "@repo/design-system/components/ui/input-otp";
 import { useLoginWithEmail, usePrivy } from "@privy-io/react-auth";
 import { useState } from "react";
+import { useAuth } from "./AuthContext";
 
 export default function EmailLoginButton() {
   const [email, setEmail] = useState("");
   const [inputState, setInputState] = useState<
     "idle" | "loading" | "success" | "error"
   >("idle");
-  const { sendCode } = useLoginWithEmail();
+  const { sendCode } = useAuth();
 
   const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/apps/app/components/daydream/LoginScreen/GoogleLoginButton.tsx
+++ b/apps/app/components/daydream/LoginScreen/GoogleLoginButton.tsx
@@ -1,4 +1,5 @@
 import { useLoginWithOAuth } from "@privy-io/react-auth";
+import { useAuth } from "./AuthContext";
 
 function GoogleIcon() {
   return (
@@ -21,7 +22,7 @@ function GoogleIcon() {
 }
 
 export default function GoogleLoginButton() {
-  const { state, loading, initOAuth } = useLoginWithOAuth();
+  const { initOAuth, oAuthState } = useAuth();
 
   const handleLogin = async () => {
     try {
@@ -35,7 +36,7 @@ export default function GoogleLoginButton() {
     <button
       className="flex items-center justify-center h-9 gap-2 py-2.5 px-4 w-1/2 border border-[#E4E4E7] rounded-[6px] bg-white"
       onClick={handleLogin}
-      disabled={loading}
+      disabled={oAuthState.status === "loading"}
     >
       <GoogleIcon />
       <span className="text-[14px] font-inter font-medium text-[#09090B]">

--- a/apps/app/components/daydream/LoginScreen/index.tsx
+++ b/apps/app/components/daydream/LoginScreen/index.tsx
@@ -10,14 +10,33 @@ import { useIsMobile } from "@repo/design-system/hooks/use-mobile";
 import useMount from "@/hooks/useMount";
 import { useTheme } from "next-themes";
 import LivepeerLogo from "../LivepeerLogo";
+import { Loader2 } from "lucide-react";
+import { useAuth } from "./AuthContext";
 
-export default function LoginScreen() {
+export default function LoginScreen({
+  isOAuthSuccessRedirect,
+}: {
+  isOAuthSuccessRedirect: boolean;
+}) {
   const isMobile = useIsMobile();
   const { setTheme } = useTheme();
+  const { oAuthState } = useAuth();
 
   useMount(() => {
     setTheme("light");
   });
+
+  // If the user is redirected from OAuth, show a loading screen to prevent displaying login for a split second
+  if (
+    isOAuthSuccessRedirect &&
+    ["initial", "loading"].includes(oAuthState.status)
+  ) {
+    return (
+      <div className="w-full h-screen flex items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen flex flex-col-reverse sm:flex-row relative w-full h-[100vh] overflow-auto">

--- a/apps/app/components/daydream/index.tsx
+++ b/apps/app/components/daydream/index.tsx
@@ -8,11 +8,14 @@ import { Loader2 } from "lucide-react";
 import MainExperience from "./MainExperience";
 import { useEffect } from "react";
 import LayoutWrapper from "./LayoutWrapper";
+import { AuthProvider } from "./LoginScreen/AuthContext";
 
 export default function Daydream({
   hasSharedPrompt,
+  isOAuthSuccessRedirect,
 }: {
   hasSharedPrompt: boolean;
+  isOAuthSuccessRedirect: boolean;
 }) {
   const { user, ready } = usePrivy();
 
@@ -31,7 +34,9 @@ export default function Daydream({
   if (!user) {
     return (
       <LayoutWrapper>
-        <LoginScreen />
+        <AuthProvider>
+          <LoginScreen isOAuthSuccessRedirect={isOAuthSuccessRedirect} />
+        </AuthProvider>
       </LayoutWrapper>
     );
   }


### PR DESCRIPTION
## Overview
When user logged in using OAuth providers i.e. Google or Discord, we were seeing the login screen for a split second on redirect. This is due to Privy provider taking a bit of time to validate the authentication. 

## Fix added
- Moved the OAuth Initialization to the top of the components so that we can verify the oauthstate and if the user has successfully auth, if so we display a loader for the time until privy authenticates the user.

