### PR TITLE
Remove sidebar Discord Community, Feedback and Documentation links

### DIFF
--- a/apps/app/components/sidebar.tsx
+++ b/apps/app/components/sidebar.tsx
@@ -135,18 +135,13 @@ export const GlobalSidebar = ({ children }: GlobalSidebarProperties) => {
       },
     ],*/
     footer: [
-      {
+      // Removed - Leaving in here in case we want to add sidebar elements back in in the future
+      /*{
         title: "Documentation",
         url: "https://pipelines.livepeer.org/docs/technical",
         external: true,
         icon: BookIcon,
-      },
-      {
-        title: "Feedback",
-        url: "https://livepeer.notion.site/15f0a348568781aab037c863d91b05e2",
-        external: true,
-        icon: LightbulbIcon,
-      },
+      }*/
     ],
   };
 

--- a/apps/app/components/sidebar.tsx
+++ b/apps/app/components/sidebar.tsx
@@ -136,12 +136,6 @@ export const GlobalSidebar = ({ children }: GlobalSidebarProperties) => {
     ],*/
     footer: [
       {
-        title: "Join Community",
-        url: "https://discord.com/invite/hxyNHeSzCK",
-        external: true,
-        icon: DiscordLogoIcon,
-      },
-      {
         title: "Documentation",
         url: "https://pipelines.livepeer.org/docs/technical",
         external: true,


### PR DESCRIPTION
Eric asked to remove the Discord link as it's duplication of the one at the top of the page. He also said the other two aren't needed.