### PR TITLE
chore: Move user to prompt selection directly

### DIFF
--- a/apps/app/components/daydream/WelcomeScreen/SelectPrompt.tsx
+++ b/apps/app/components/daydream/WelcomeScreen/SelectPrompt.tsx
@@ -4,6 +4,7 @@ import useScrollView from "@/hooks/useScrollView";
 import { useEffect } from "react";
 import track from "@/lib/track";
 import { usePrivy } from "@privy-io/react-auth";
+import useMount from "@/hooks/useMount";
 
 interface PromptOption {
   id: string;
@@ -47,6 +48,10 @@ export default function SelectPrompt() {
     useOnboard();
   const componentRef = useScrollView(currentStep === "prompt");
   const { user } = usePrivy();
+
+  useMount(() => {
+    localStorage.setItem(`hasSeenSelectPrompt-${user?.id}`, "true");
+  });
 
   useEffect(() => {
     if (currentStep === "prompt") {

--- a/apps/app/components/daydream/index.tsx
+++ b/apps/app/components/daydream/index.tsx
@@ -63,8 +63,11 @@ function DaydreamRenderer() {
     const checkPermissions = async () => {
       try {
         if ("permissions" in navigator) {
-          const hasVisited = localStorage.getItem(
+          const hasVisitedMainPage = localStorage.getItem(
             `hasSeenLandingPage-${user?.id}`,
+          );
+          const hasVisitedSelectPrompt = localStorage.getItem(
+            `hasSeenSelectPrompt-${user?.id}`,
           );
           const cameraPermission = await navigator.permissions.query({
             name: "camera" as PermissionName,
@@ -72,8 +75,11 @@ function DaydreamRenderer() {
 
           if (cameraPermission.state === "granted") {
             setCameraPermission("granted");
-            if (hasVisited) {
+            if (hasVisitedMainPage) {
               setCurrentStep("main");
+            } else if (hasVisitedSelectPrompt) {
+              // If the user has visited the select prompt and not the main page, user is still in onboarding
+              setCurrentStep("prompt");
             }
           }
         }


### PR DESCRIPTION
Currently, we validate the camera permissions and redirect users to the main page if the permission is granted.

In Firefox browsers, despite the permission granted - the browser requires user to explicitly allow video every single time. This causes a feeling that the popup has arrived even before the user has requested, but in essence, its a browser behaviour and user has already consented to grant permissions previously. 

We have now updated the behaviour to move the user directly to prompt selection page - thereby indicating that the camera access request part is complete.

NOTE: In Firefox, it will still request for camera permissions from the user everytime. This is NOT a bug.