### PR TITLE
chore: add system status to daydream

### DIFF
--- a/apps/app/components/daydream/SystemStatus.tsx
+++ b/apps/app/components/daydream/SystemStatus.tsx
@@ -1,0 +1,24 @@
+import { useSystemStatus } from "@/hooks/useSystemStatus";
+import { cn } from "@repo/design-system/lib/utils";
+import { ActivityIcon } from "lucide-react";
+
+export const STATUS_PAGE_URL = "https://livepeerdaydream.statuspage.io/";
+
+export default function SystemStatus() {
+  const status = useSystemStatus();
+
+  return (
+    <div className="w-4 h-4 relative">
+      <ActivityIcon className="w-4 h-4 text-foreground" />
+      <div
+        className={cn(
+          "absolute -top-1 -right-1 h-2 w-2 bg-transparent rounded-full",
+          status === "none" && "bg-green-500",
+          status === "minor" && "bg-yellow-500",
+          status === "major" && "bg-orange-500",
+          status === "critical" && "bg-red-500",
+        )}
+      ></div>
+    </div>
+  );
+}

--- a/apps/app/components/sidebar.tsx
+++ b/apps/app/components/sidebar.tsx
@@ -16,15 +16,14 @@ import {
   useSidebar,
 } from "@repo/design-system/components/ui/sidebar";
 import { useIsMobile } from "@repo/design-system/hooks/use-mobile";
-import { BookIcon, LightbulbIcon } from "lucide-react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { usePrivy } from "@privy-io/react-auth";
-import { DiscordLogoIcon } from "@radix-ui/react-icons";
 import User from "components/header/user";
 import { cn } from "@repo/design-system/lib/utils";
 import { useAppConfig } from "@/hooks/useAppConfig";
+import SystemStatus, { STATUS_PAGE_URL } from "./daydream/SystemStatus";
 
 type GlobalSidebarProperties = {
   readonly children: ReactNode;
@@ -294,18 +293,43 @@ export const GlobalSidebar = ({ children }: GlobalSidebarProperties) => {
                   </SidebarMenuItem>
                 ))}
                 {key === "footer" && (
-                  <SidebarMenuItem key="My Account" className="w-full">
-                    <SidebarMenuButton
-                      className={cn(
-                        "hover:bg-muted cursor-pointer",
-                        isMobile && _sidebar.openMobile && "ml-4",
-                      )}
-                      asChild
-                      tooltip="My Account"
-                    >
-                      <User />
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
+                  <>
+                    <SidebarMenuItem key="System Status" className="w-full">
+                      <SidebarMenuButton
+                        className={cn(
+                          "hover:bg-muted cursor-pointer",
+                          isMobile && _sidebar.openMobile && "ml-4",
+                        )}
+                        asChild
+                        tooltip="System Status"
+                        onClick={() => window.open(STATUS_PAGE_URL, "_blank")}
+                      >
+                        <div>
+                          <SystemStatus />
+                          <span
+                            className={cn(
+                              "hidden ml-1.5",
+                              _sidebar.openMobile && "block",
+                            )}
+                          >
+                            System Status
+                          </span>
+                        </div>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem key="My Account" className="w-full">
+                      <SidebarMenuButton
+                        className={cn(
+                          "hover:bg-muted cursor-pointer",
+                          isMobile && _sidebar.openMobile && "ml-4",
+                        )}
+                        asChild
+                        tooltip="My Account"
+                      >
+                        <User />
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  </>
                 )}
               </SidebarMenu>
             </SidebarGroup>

--- a/apps/app/hooks/useSystemStatus.ts
+++ b/apps/app/hooks/useSystemStatus.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+const STATUS_CHECK_ENDPOINT =
+  "https://livepeerdaydream.statuspage.io/api/v2/status.json";
+
+// Check documentation for more details on API and types: https://livepeerdaydream.statuspage.io/api/v2/
+type StatusIndicator = "none" | "minor" | "major" | "critical";
+
+export const useSystemStatus = () => {
+  const [status, setStatus] = useState<StatusIndicator | null>(null);
+
+  useEffect(() => {
+    const fetchSystemStatus = async () => {
+      try {
+        const response = await fetch(STATUS_CHECK_ENDPOINT);
+        const data = await response.json();
+        const status = data?.status?.indicator as StatusIndicator;
+        setStatus(status);
+      } catch (error) {
+        console.error("Error fetching system status");
+      }
+    };
+    fetchSystemStatus();
+  }, []);
+
+  return status;
+};


### PR DESCRIPTION
- Added a button on the sidebar to navigate to the status endpoint.
- Added a hook to fetch the systems operational status and display an indicator on the icon

<img width="200" alt="image" src="https://github.com/user-attachments/assets/9e481536-6993-4cd7-9c3d-86747d15d159" />
