### PR TITLE
feat: Add DB persistence to onboarding steps

### DIFF
--- a/apps/app/components/daydream/OnboardContext.tsx
+++ b/apps/app/components/daydream/OnboardContext.tsx
@@ -7,7 +7,6 @@ export type CameraPermission = "prompt" | "granted" | "denied";
 
 interface OnboardContextType {
   // Current step in the onboarding flow
-  initialStep: OnboardingStep;
   currentStep: OnboardingStep;
   // Initialization of user and camera permissions
   isInitializing: boolean;
@@ -45,15 +44,9 @@ export function OnboardProvider({
   const [selectedPrompt, setSelectedPrompt] = useState<string | null>(null);
   const [isInitializing, setIsInitializing] = useState(true);
   const [isFadingOut, setFadingOut] = useState(false);
-  const [initialStep, _] = useState<OnboardingStep>(() => {
-    // TODO: Persist this step in DB and move away from local storage
-    const step = localStorage.getItem("daydream_onboarding_step");
-    return step ? (step as OnboardingStep) : "persona";
-  });
 
   const value = useMemo(
     () => ({
-      initialStep,
       currentStep,
       cameraPermission,
       selectedPersonas,
@@ -69,7 +62,6 @@ export function OnboardProvider({
       hasSharedPrompt,
     }),
     [
-      initialStep,
       currentStep,
       cameraPermission,
       selectedPersonas,

--- a/apps/app/components/daydream/WelcomeScreen/CameraAccess.tsx
+++ b/apps/app/components/daydream/WelcomeScreen/CameraAccess.tsx
@@ -1,10 +1,10 @@
-import Image from "next/image";
 import { useIsMobile } from "@repo/design-system/hooks/use-mobile";
 import { CameraIcon, CheckIcon } from "lucide-react";
 import { useOnboard } from "../OnboardContext";
 import track from "@/lib/track";
 import { usePrivy } from "@privy-io/react-auth";
 import { cn } from "@repo/design-system/lib/utils";
+import { updateUserAdditionalDetails } from "@/app/actions/user";
 
 export const useMediaPermissions = () => {
   const { setCameraPermission } = useOnboard();
@@ -84,6 +84,7 @@ export const useMediaPermissions = () => {
 
 export default function CameraAccess() {
   const isMobile = useIsMobile();
+  const { user } = usePrivy();
   const { currentStep, cameraPermission, setCurrentStep, hasSharedPrompt } =
     useOnboard();
   const { requestMediaPermissions } = useMediaPermissions();
@@ -96,7 +97,9 @@ export default function CameraAccess() {
     const hasPermissions = await requestMediaPermissions();
     if (hasPermissions) {
       setCurrentStep(hasSharedPrompt ? "main" : "prompt");
-      localStorage.setItem("daydream_onboarding_step", "prompt");
+      await updateUserAdditionalDetails(user!, {
+        next_onboarding_step: hasSharedPrompt ? "main" : "prompt",
+      });
     }
   };
 

--- a/apps/app/components/daydream/WelcomeScreen/Personas.tsx
+++ b/apps/app/components/daydream/WelcomeScreen/Personas.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 import { useOnboard } from "../OnboardContext";
 import track from "@/lib/track";
 import { usePrivy } from "@privy-io/react-auth";
-import { updateUserPersonas } from "@/components/header/action";
+import { updateUserAdditionalDetails } from "@/app/actions/user";
 
 const personas = [
   "Personal Use",
@@ -49,8 +49,11 @@ export default function Personas() {
       user_id: user?.id,
     });
     setCurrentStep(cameraPermission === "granted" ? "prompt" : "camera");
-    await updateUserPersonas(user!, selectedPersonas);
-    localStorage.setItem("daydream_onboarding_step", "camera");
+    await updateUserAdditionalDetails(user!, {
+      next_onboarding_step: "camera",
+      personas: selectedPersonas,
+      custom_persona: customPersona,
+    });
   };
 
   const isButtonDisabled =

--- a/apps/app/components/daydream/WelcomeScreen/SelectPrompt.tsx
+++ b/apps/app/components/daydream/WelcomeScreen/SelectPrompt.tsx
@@ -7,6 +7,7 @@ import { usePrivy } from "@privy-io/react-auth";
 import useMount from "@/hooks/useMount";
 import { Separator } from "@repo/design-system/components/ui/separator";
 import { InfoIcon } from "lucide-react";
+import { updateUserAdditionalDetails } from "@/app/actions/user";
 
 interface PromptOption {
   id: string;
@@ -77,15 +78,17 @@ export default function SelectPrompt() {
     return null;
   }
 
-  const handleSelectPrompt = (prompt: string) => {
+  const handleSelectPrompt = async (prompt: string) => {
     setFadingOut(true);
     setSelectedPrompt(prompt);
-    localStorage.setItem("daydream_onboarding_step", "main");
     // Wait for the fade out to complete before setting the current step to main
     setTimeout(() => {
       setCurrentStep("main");
       window && window.scrollTo({ top: 0, behavior: "instant" });
     }, 1000);
+    await updateUserAdditionalDetails(user!, {
+      next_onboarding_step: "main",
+    });
   };
 
   return (


### PR DESCRIPTION
- Added a server action to create and update user table data with the following schema. `additional_details` is already an existing field in the Users table, we are reusing it.
```
additional_details: {
    next_onboarding_step: "persona" | "camera" | "prompt" | "main",
    personas: [],
    customPersona: ""
}
```
- Updated the onboarding logic to move to DB persisted step instead of local storage, now the user will login into the exact onboarding step they left off at, even on other devices.