### PR TITLE
chore: Fix selected personas lost after refresh, prompt styles

### DIFF
--- a/apps/app/components/daydream/OnboardContext.tsx
+++ b/apps/app/components/daydream/OnboardContext.tsx
@@ -13,14 +13,18 @@ interface OnboardContextType {
   hasSharedPrompt: boolean;
   cameraPermission: CameraPermission;
   // Selected options for each step
-  selectedPersonas: string[] | null;
+  selectedPersonas: string[];
+  customPersona: string;
   selectedPrompt: string | null;
   // When a prompt is selected, we fade out the welcome screen
   isFadingOut: boolean;
   // Methods to update state
   setCurrentStep: (step: OnboardingStep) => void;
   setCameraPermission: (permission: CameraPermission) => void;
-  setSelectedPersonas: (personas: string[]) => void;
+  setSelectedPersonas: (
+    personas: string[] | ((prev: string[]) => string[]),
+  ) => void;
+  setCustomPersona: (persona: string) => void;
   setSelectedPrompt: (prompt: string | null) => void;
   setIsInitializing: (initializing: boolean) => void;
   setFadingOut: (fadingOut: boolean) => void;
@@ -41,6 +45,7 @@ export function OnboardProvider({
   const [cameraPermission, setCameraPermission] =
     useState<CameraPermission>("prompt");
   const [selectedPersonas, setSelectedPersonas] = useState<string[]>([]);
+  const [customPersona, setCustomPersona] = useState<string>("");
   const [selectedPrompt, setSelectedPrompt] = useState<string | null>(null);
   const [isInitializing, setIsInitializing] = useState(true);
   const [isFadingOut, setFadingOut] = useState(false);
@@ -50,12 +55,14 @@ export function OnboardProvider({
       currentStep,
       cameraPermission,
       selectedPersonas,
+      customPersona,
       selectedPrompt,
       isInitializing,
       isFadingOut,
       setCurrentStep,
       setCameraPermission,
       setSelectedPersonas,
+      setCustomPersona,
       setSelectedPrompt,
       setIsInitializing,
       setFadingOut,
@@ -65,6 +72,7 @@ export function OnboardProvider({
       currentStep,
       cameraPermission,
       selectedPersonas,
+      customPersona,
       selectedPrompt,
       isInitializing,
       isFadingOut,

--- a/apps/app/components/daydream/WelcomeScreen/CameraAccess.tsx
+++ b/apps/app/components/daydream/WelcomeScreen/CameraAccess.tsx
@@ -140,7 +140,7 @@ export default function CameraAccess() {
               you click "record"
             </p>
           </div>
-          {cameraPermission === "granted" ? (
+          {cameraPermission === "granted" || currentStep === "prompt" ? (
             <div className="bg-[#95B4BE] shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] rounded-md px-2 py-2 text-black font-inter text-[13px] leading-[1.21] flex items-center justify-center gap-2 animate-[bounce_0.5s_ease-in-out]">
               <CheckIcon className="w-4 h-4 stroke-[3px]" />
             </div>

--- a/apps/app/components/daydream/WelcomeScreen/Personas.tsx
+++ b/apps/app/components/daydream/WelcomeScreen/Personas.tsx
@@ -21,9 +21,15 @@ const personas = [
 
 export default function Personas() {
   const { user } = usePrivy();
-  const { currentStep, setCurrentStep, cameraPermission } = useOnboard();
-  const [selectedPersonas, setSelectedPersonas] = useState<string[]>([]);
-  const [customPersona, setCustomPersona] = useState("");
+  const {
+    currentStep,
+    setCurrentStep,
+    cameraPermission,
+    selectedPersonas,
+    setSelectedPersonas,
+    customPersona,
+    setCustomPersona,
+  } = useOnboard();
 
   useEffect(() => {
     track("daydream_persona_viewed", {

--- a/apps/app/components/daydream/WelcomeScreen/SelectPrompt.tsx
+++ b/apps/app/components/daydream/WelcomeScreen/SelectPrompt.tsx
@@ -123,7 +123,7 @@ export default function SelectPrompt() {
                     className="object-cover"
                     priority
                   />
-                  <div className="absolute bottom-0 left-0 right-0 py-2 group-hover:py-4 bg-[rgba(28,28,28,0.25)] backdrop-blur-[24px] flex flex-col items-center justify-center gap-1 transition-all duration-300 ease-out">
+                  <div className="absolute bottom-0 left-0 right-0 py-2 group-hover:py-4 bg-[rgba(28,28,28,0.25)] backdrop-blur-[24px] flex flex-col items-center justify-center gap-2 transition-all duration-300 ease-out">
                     <div className="flex items-center gap-2">
                       <p className="font-inter font-semibold text-[12px] sm:text-[14px] leading-[1em] tracking-[-1.1%] text-[#EDEDED] text-center">
                         {option.title}


### PR DESCRIPTION
- Highlighted personas were lost on refresh, now persisted from DB
- Padding of the title in prompt selection view - added more padding.
- Moved tracking to after user initialization processing to display onboarding faster to the user.