### PR TITLE
fix: Cluttered screen in landscape mode, resort to mobile view

### DIFF
--- a/apps/app/components/playground/broadcast.tsx
+++ b/apps/app/components/playground/broadcast.tsx
@@ -162,7 +162,7 @@ export function BroadcastWithControls({ className }: { className?: string }) {
           !collapsed
             ? "w-full h-full"
             : isMobile
-              ? "!w-full !h-12 bg-muted-background rounded-2xl"
+              ? "!w-full !h-12 bg-muted-background rounded-2xl max-w-[calc(min(100%,calc((100vh-16rem)*16/9)))] mx-auto md:aspect-video aspect-square"
               : "!w-12 !h-12 rounded-full",
         )}
         style={collapsed && !isMobile ? { width: "3rem", height: "3rem" } : {}}

--- a/apps/app/components/welcome/featured/ManagedBroadcast.tsx
+++ b/apps/app/components/welcome/featured/ManagedBroadcast.tsx
@@ -30,7 +30,7 @@ export function ManagedBroadcast() {
     <div
       className={cn(
         "transition-all duration-100",
-        isMobile ? "mx-4 w-auto -mt-2 mb-4" : "absolute z-50",
+        isMobile ? "mx-4 w-auto mb-4" : "absolute z-50",
       )}
       style={
         isMobile

--- a/apps/app/hooks/useMobileStore.ts
+++ b/apps/app/hooks/useMobileStore.ts
@@ -2,7 +2,8 @@
 
 import { create } from "zustand";
 
-const MOBILE_BREAKPOINT = 768;
+const MOBILE_BREAKPOINT_WIDTH = 768;
+const MOBILE_BREAKPOINT_HEIGHT = 768;
 
 interface MobileStore {
   isMobile: boolean;
@@ -14,10 +15,16 @@ const useMobileStore = create<MobileStore>(set => {
   const initializeListener = () => {
     if (typeof window === "undefined" || listenerInitialized) return;
 
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mql = window.matchMedia(
+      `(max-width: ${MOBILE_BREAKPOINT_WIDTH - 1}px) or (max-height: ${MOBILE_BREAKPOINT_HEIGHT - 1}px)`,
+    );
 
     const onChange = () => {
-      set({ isMobile: window.innerWidth < MOBILE_BREAKPOINT });
+      set({
+        isMobile:
+          window.innerWidth < MOBILE_BREAKPOINT_WIDTH ||
+          window.innerHeight < MOBILE_BREAKPOINT_HEIGHT,
+      });
     };
 
     mql.addEventListener("change", onChange);
@@ -32,7 +39,9 @@ const useMobileStore = create<MobileStore>(set => {
 
   return {
     isMobile:
-      typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT,
+      (typeof window !== "undefined" &&
+        window.innerWidth < MOBILE_BREAKPOINT_WIDTH) ||
+      window.innerHeight < MOBILE_BREAKPOINT_HEIGHT,
   };
 });
 

--- a/packages/design-system/hooks/use-mobile.tsx
+++ b/packages/design-system/hooks/use-mobile.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
-const MOBILE_BREAKPOINT = 768;
+const MOBILE_BREAKPOINT_WIDTH = 768;
+const MOBILE_BREAKPOINT_HEIGHT = 768;
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
@@ -8,12 +9,20 @@ export function useIsMobile() {
   );
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mql = window.matchMedia(
+      `(max-width: ${MOBILE_BREAKPOINT_WIDTH - 1}px) or (max-height: ${MOBILE_BREAKPOINT_HEIGHT - 1}px)`,
+    );
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(
+        window.innerWidth < MOBILE_BREAKPOINT_WIDTH ||
+          window.innerHeight < MOBILE_BREAKPOINT_HEIGHT,
+      );
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(
+      window.innerWidth < MOBILE_BREAKPOINT_WIDTH ||
+        window.innerHeight < MOBILE_BREAKPOINT_HEIGHT,
+    );
     return () => mql.removeEventListener("change", onChange);
   }, []);
 


### PR DESCRIPTION
In landscape mode, the input and output video are almost overlapping causing a clutter on the screen, removed by resorting to mobile view when the height of the screen is 768px or less.

600px screen view:
<img width="1167" alt="image" src="https://github.com/user-attachments/assets/4dcfe9ef-f6d8-4479-9363-2b8b9092e6a6" />
