### PR TITLE
fix: shadow container on login screen

### DIFF
--- a/apps/app/components/daydream/LoginScreen/index.tsx
+++ b/apps/app/components/daydream/LoginScreen/index.tsx
@@ -153,36 +153,38 @@ export default function LoginScreen({
           Transform your video
         </h1>
 
-        <div className="relative h-[calc(40dvh)] sm:max-h-none sm:h-[calc(100dvh-200px)] overflow-hidden shadow-[12px_24px_33px_0px_#0913168A] rounded-[26px]">
-          <div
-            className="absolute -top-[209.5px] -right-[209.5px] w-[419px] h-[419px] rounded-full mix-blend-screen z-10"
-            style={{
-              background:
-                "radial-gradient(circle, rgba(45, 128, 148, 0.79) 0%, rgba(45, 128, 148, 0.3) 35%, rgb(84 163 182 / 0%) 70%, rgba(84, 163, 182, 0) 100%)",
-            }}
-          />
-          <div
-            className="absolute -top-[159.5px] -left-[259.5px] w-[419px] h-[419px] rounded-full mix-blend-screen z-10"
-            style={{
-              background:
-                "radial-gradient(circle, rgba(45, 128, 148, 0.79) 0%, rgba(45, 128, 148, 0.3) 35%, rgb(84 163 182 / 0%) 70%, rgba(84, 163, 182, 0) 100%)",
-            }}
-          />
-          <div
-            className="absolute -bottom-[209.5px] -left-[209.5px] w-[419px] h-[419px] rounded-full mix-blend-screen z-10"
-            style={{
-              background:
-                "radial-gradient(circle, rgba(45, 128, 148, 0.39) 0%, rgba(45, 128, 148, 0.1) 35%, rgb(84 163 182 / 0%) 70%, rgba(84, 163, 182, 0) 100%)",
-            }}
-          />
-          <video
-            src="/daydream.mp4"
-            autoPlay
-            muted
-            loop
-            playsInline
-            className="w-full h-full rounded-[26px]"
-          />
+        <div className="flex flex-col items-center justify-center w-full h-full">
+          <div className="relative w-fit overflow-hidden shadow-[12px_24px_33px_0px_#0913168A] rounded-[26px] items-center sm:-mt-10">
+            <div
+              className="absolute -top-[209.5px] -right-[209.5px] w-[419px] h-[419px] rounded-full mix-blend-screen z-10"
+              style={{
+                background:
+                  "radial-gradient(circle, rgba(45, 128, 148, 0.79) 0%, rgba(45, 128, 148, 0.3) 35%, rgb(84 163 182 / 0%) 70%, rgba(84, 163, 182, 0) 100%)",
+              }}
+            />
+            <div
+              className="absolute -top-[159.5px] -left-[259.5px] w-[419px] h-[419px] rounded-full mix-blend-screen z-10"
+              style={{
+                background:
+                  "radial-gradient(circle, rgba(45, 128, 148, 0.79) 0%, rgba(45, 128, 148, 0.3) 35%, rgb(84 163 182 / 0%) 70%, rgba(84, 163, 182, 0) 100%)",
+              }}
+            />
+            <div
+              className="absolute -bottom-[209.5px] -left-[209.5px] w-[419px] h-[419px] rounded-full mix-blend-screen z-10"
+              style={{
+                background:
+                  "radial-gradient(circle, rgba(45, 128, 148, 0.39) 0%, rgba(45, 128, 148, 0.1) 35%, rgb(84 163 182 / 0%) 70%, rgba(84, 163, 182, 0) 100%)",
+              }}
+            />
+            <video
+              src="/daydream.mp4"
+              autoPlay
+              muted
+              loop
+              playsInline
+              className="w-full h-full max-h-[calc(100dvh-200px)] rounded-[26px]"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/apps/app/components/footer/stream-info.tsx
+++ b/apps/app/components/footer/stream-info.tsx
@@ -35,7 +35,7 @@ export function StreamInfo({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "fixed bottom-4 right-16 flex items-center gap-2 text-xs text-gray-500 z-10",
+        "fixed bottom-4 right-20 flex items-center gap-2 text-xs text-gray-500 z-10",
         isFullscreen && "hidden",
         className,
       )}


### PR DESCRIPTION
- Adjusted the shadow container width and styles to match the placeholder video and prevent overflow shadows on mobile, small and large screens.
- Moved the debug info position to access copy button easily

before:
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/f4a3e0fd-5032-4e93-abf0-ca431700cf49" />


after:
<img width="1261" alt="Screenshot 2025-04-04 at 9 52 22 AM" src="https://github.com/user-attachments/assets/e05a28d5-5d8d-4579-b12e-332a0e315334" />
