### PR TITLE
fix: camera permission issues when user resets camera manually

### DIFF
--- a/apps/app/app/api/metrics/beacon/route.ts
+++ b/apps/app/app/api/metrics/beacon/route.ts
@@ -43,22 +43,23 @@ export async function POST(request: NextRequest) {
     const appConfig = getAppConfig(request.nextUrl.searchParams);
     const ip =
       appConfig.environment === "dev"
-        ? "development.fake.ip" 
+        ? "development.fake.ip"
         : forwardedFor
           ? forwardedFor.split(",")[0].trim()
           : "";
-    
+
     const userAgent = request.headers.get("user-agent") || "";
 
-    const geoData = ip && ip !== "127.0.0.1" && ip !== "::1" 
-      ? await getGeoData(ip) 
-      : {
-          city: "",
-          region: "",
-          country: "",
-          latitude: "",
-          longitude: "",
-        };
+    const geoData =
+      ip && ip !== "127.0.0.1" && ip !== "::1"
+        ? await getGeoData(ip)
+        : {
+            city: "",
+            region: "",
+            country: "",
+            latitude: "",
+            longitude: "",
+          };
 
     const { viewer_info, broadcaster_info, ...cleanData } = data;
 

--- a/apps/app/app/api/metrics/log/route.ts
+++ b/apps/app/app/api/metrics/log/route.ts
@@ -33,7 +33,7 @@ export async function POST(request: NextRequest) {
     if (!eventType || !data || !app || !host) {
       return NextResponse.json(
         { error: "Missing required fields" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -45,18 +45,19 @@ export async function POST(request: NextRequest) {
         : forwardedFor
           ? forwardedFor.split(",")[0].trim()
           : "";
-    
+
     const userAgent = request.headers.get("user-agent") || "";
 
-    const geoData = ip && ip !== "127.0.0.1" && ip !== "::1" 
-      ? await getGeoData(ip) 
-      : {
-          city: "",
-          region: "",
-          country: "",
-          latitude: "",
-          longitude: "",
-        };
+    const geoData =
+      ip && ip !== "127.0.0.1" && ip !== "::1"
+        ? await getGeoData(ip)
+        : {
+            city: "",
+            region: "",
+            country: "",
+            latitude: "",
+            longitude: "",
+          };
 
     const { viewer_info, broadcaster_info, ...cleanData } = data;
 
@@ -77,7 +78,7 @@ export async function POST(request: NextRequest) {
     console.error("Error processing Kafka request:", error);
     return NextResponse.json(
       { error: "Failed to process Kafka request" },
-      { status: 500 }
+      { status: 500 },
     );
   }
-} 
+}

--- a/apps/app/components/daydream/WelcomeScreen/CameraAccess.tsx
+++ b/apps/app/components/daydream/WelcomeScreen/CameraAccess.tsx
@@ -115,7 +115,9 @@ export default function CameraAccess() {
           currentStep === "camera" && "cursor-pointer",
         )}
         onClick={
-          currentStep === "camera" ? handleRequestMediaPermissions : undefined
+          cameraPermission !== "granted"
+            ? handleRequestMediaPermissions
+            : undefined
         }
       >
         <div
@@ -140,7 +142,7 @@ export default function CameraAccess() {
               you click &quot;record&quot;
             </p>
           </div>
-          {cameraPermission === "granted" || currentStep === "prompt" ? (
+          {cameraPermission === "granted" ? (
             <div className="bg-[#95B4BE] shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)] rounded-md px-2 py-2 text-black font-inter text-[13px] leading-[1.21] flex items-center justify-center gap-2 animate-[bounce_0.5s_ease-in-out]">
               <CheckIcon className="w-4 h-4 stroke-[3px]" />
             </div>

--- a/apps/app/components/playground/broadcast.tsx
+++ b/apps/app/components/playground/broadcast.tsx
@@ -28,6 +28,7 @@ import { sendKafkaEvent } from "@/lib/analytics/event-middleware";
 import { useDreamshaperStore } from "@/hooks/useDreamshaper";
 import { create } from "zustand";
 import { usePrivy } from "@/hooks/usePrivy";
+import { useOnboard } from "../daydream/OnboardContext";
 
 const StatusMonitor = () => {
   const { user } = usePrivy();
@@ -54,7 +55,7 @@ const StatusMonitor = () => {
           },
           "daydream",
           "server",
-          user || undefined
+          user || undefined,
         );
       };
 
@@ -83,6 +84,7 @@ const videoId = "live-video";
 
 export function BroadcastWithControls({ className }: { className?: string }) {
   const { streamUrl: ingestUrl } = useDreamshaperStore();
+  const { cameraPermission } = useOnboard();
   const [isPiP, setIsPiP] = useState(false);
 
   const { collapsed, setCollapsed, toggleCollapsed } = useBroadcastUIStore();
@@ -109,6 +111,15 @@ export function BroadcastWithControls({ className }: { className?: string }) {
     };
   }, []);
 
+  if (cameraPermission !== "granted") {
+    return (
+      <BroadcastLoading
+        title="Cannot access camera"
+        description="Please grant camera permission to broadcast."
+      />
+    );
+  }
+
   if (!ingestUrl) {
     return (
       <BroadcastLoading
@@ -133,13 +144,15 @@ export function BroadcastWithControls({ className }: { className?: string }) {
       video={true}
       aspectRatio={16 / 9}
       ingestUrl={ingestUrl}
-      {...{iceServers: {
-        urls: [
-          "stun:stun.l.google.com:19302",
-          "stun:stun1.l.google.com:19302",
-          "stun:stun.cloudflare.com:3478",
-        ],
-      }} as any}
+      {...({
+        iceServers: {
+          urls: [
+            "stun:stun.l.google.com:19302",
+            "stun:stun1.l.google.com:19302",
+            "stun:stun.cloudflare.com:3478",
+          ],
+        },
+      } as any)}
       storage={null}
     >
       <StatusMonitor />
@@ -492,22 +505,22 @@ export const BroadcastLoading = ({
   <div className="relative w-full px-3 md:px-3 py-3 gap-3 flex-col-reverse flex aspect-video bg-white/10 overflow-hidden rounded-sm">
     <div className="flex justify-between">
       <div className="flex items-center gap-2">
-        <div className="w-6 h-6 animate-pulse bg-white/5 overflow-hidden rounded-lg" />
-        <div className="w-16 h-6 md:w-20 md:h-7 animate-pulse bg-white/5 overflow-hidden rounded-lg" />
+        <div className="w-6 h-6 animate-pulse bg-background/5 overflow-hidden rounded-lg" />
+        <div className="w-16 h-6 md:w-20 md:h-7 animate-pulse bg-background/5 overflow-hidden rounded-lg" />
       </div>
 
       <div className="flex items-center gap-2">
-        <div className="w-6 h-6 animate-pulse bg-white/5 overflow-hidden rounded-lg" />
-        <div className="w-6 h-6 animate-pulse bg-white/5 overflow-hidden rounded-lg" />
+        <div className="w-6 h-6 animate-pulse bg-background/5 overflow-hidden rounded-lg" />
+        <div className="w-6 h-6 animate-pulse bg-background/5 overflow-hidden rounded-lg" />
       </div>
     </div>
-    <div className="w-full h-2 animate-pulse bg-white/5 overflow-hidden rounded-lg" />
+    <div className="w-full h-2 animate-pulse bg-background/5 overflow-hidden rounded-lg" />
 
     {title && (
       <div className="absolute flex flex-col gap-1 inset-10 text-center justify-center items-center">
-        <span className="text-white text-lg font-medium">{title}</span>
+        <span className="text-foreground text-lg font-medium">{title}</span>
         {description && (
-          <span className="text-sm text-white/80">{description}</span>
+          <span className="text-sm text-foreground/80">{description}</span>
         )}
       </div>
     )}

--- a/apps/app/components/welcome/featured/Dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/Dreamshaper.tsx
@@ -80,7 +80,7 @@ export default function Dreamshaper() {
         eventData,
         "daydream",
         window.location.hostname,
-        user || undefined
+        user || undefined,
       );
     };
 
@@ -100,7 +100,7 @@ export default function Dreamshaper() {
           eventData,
           "daydream",
           window.location.hostname,
-          user || undefined
+          user || undefined,
         );
       }
 

--- a/apps/app/components/welcome/featured/Overlay.tsx
+++ b/apps/app/components/welcome/featured/Overlay.tsx
@@ -18,7 +18,7 @@ export default function Overlay({ statusMessage }: OverlayProps) {
     >
       <Logo className="w-8 h-8 sm:w-10 sm:h-10 mb-6" />
       <div className="flex flex-col items-center gap-6 justify-center max-w-80 text-foreground sm:mb-6">
-        <p className="shimmer-text shimmer-slow text-lg sm:text-xl font-semibold">
+        <p className="shimmer-text text-lg sm:text-xl font-semibold">
           {statusMessage ? (
             statusMessage
           ) : (

--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -122,13 +122,15 @@ export const LivepeerPlayer = () => {
         backoffMax={1000}
         timeout={300000}
         lowLatency="force"
-        {...{iceServers: {
-          urls: [
-            "stun:stun.l.google.com:19302",
-            "stun:stun1.l.google.com:19302",
-            "stun:stun.cloudflare.com:3478",
-          ],
-        }} as any}
+        {...({
+          iceServers: {
+            urls: [
+              "stun:stun.l.google.com:19302",
+              "stun:stun1.l.google.com:19302",
+              "stun:stun.cloudflare.com:3478",
+            ],
+          },
+        } as any)}
         onError={handleError}
       >
         <div
@@ -259,9 +261,7 @@ export const PlayerLoading = ({
   </div>
 );
 
-const useFirstFrameLoaded = ({
-  __scopeMedia,
-}: Player.MediaScopedProps) => {
+const useFirstFrameLoaded = ({ __scopeMedia }: Player.MediaScopedProps) => {
   const { user } = usePrivy();
   const { stream, pipeline } = useDreamshaperStore();
   const startTime = useRef(Date.now());
@@ -284,7 +284,7 @@ const useFirstFrameLoaded = ({
         },
         "daydream",
         "server",
-        user || undefined
+        user || undefined,
       );
     };
     sendEvent();
@@ -309,7 +309,7 @@ const useFirstFrameLoaded = ({
           },
           "daydream",
           "server",
-          user || undefined
+          user || undefined,
         );
       sendEvent();
     }

--- a/apps/app/components/welcome/featured/videojs-player.tsx
+++ b/apps/app/components/welcome/featured/videojs-player.tsx
@@ -232,7 +232,7 @@ const VideoJSPlayer: React.FC<VideoJSPlayerProps> = ({
         },
         "daydream",
         "server",
-        user || undefined
+        user || undefined,
       );
     };
     sendFirstFrameEvent();

--- a/apps/app/hooks/useFallbackDetection.ts
+++ b/apps/app/hooks/useFallbackDetection.ts
@@ -12,21 +12,24 @@ export const useFallbackDetection = (playbackId: string) => {
   const lastErrorTimeRef = useRef<number | null>(null);
   const errorIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const { user } = usePrivy();
-  
-  const trackFallbackEvent = useCallback((reason: string, errorDetails?: string) => {
-    sendKafkaEvent(
-      "stream_trace",
-      {
-        type: "app_player_fallback_to_videojs",
-        playback_id: playbackId,
-        reason: reason,
-        error_details: errorDetails || "",
-      },
-      "daydream",
-      "server",
-      user || undefined
-    );
-  }, [playbackId, user]);
+
+  const trackFallbackEvent = useCallback(
+    (reason: string, errorDetails?: string) => {
+      sendKafkaEvent(
+        "stream_trace",
+        {
+          type: "app_player_fallback_to_videojs",
+          playback_id: playbackId,
+          reason: reason,
+          error_details: errorDetails || "",
+        },
+        "daydream",
+        "server",
+        user || undefined,
+      );
+    },
+    [playbackId, user],
+  );
 
   const handleError = useCallback(
     (error: any) => {
@@ -74,7 +77,10 @@ export const useFallbackDetection = (playbackId: string) => {
           if (timeSinceLastError > TIME_TO_FALLBACK_VIDEOJS_MS && !isPlaying) {
             console.warn("Switching to VideoJS fallback player.");
             setUseFallbackPlayer(true);
-            trackFallbackEvent("timeout_error_reached", `Last error time: ${lastErrorTime}`);
+            trackFallbackEvent(
+              "timeout_error_reached",
+              `Last error time: ${lastErrorTime}`,
+            );
 
             if (errorIntervalRef.current) {
               clearInterval(errorIntervalRef.current);
@@ -103,5 +109,3 @@ export const useFallbackDetection = (playbackId: string) => {
 
   return { useFallbackPlayer, handleError, trackFallbackEvent };
 };
-
-

--- a/apps/app/lib/analytics/event-middleware.ts
+++ b/apps/app/lib/analytics/event-middleware.ts
@@ -24,7 +24,7 @@ export function standardizeEventData(
   data: any,
   app: string,
   host: string,
-  user?: User
+  user?: User,
 ): StandardizedEvent {
   const standardizedData: BaseEventData = {
     type: data.type,
@@ -51,14 +51,20 @@ export function sendBeaconEvent(
   data: any,
   app: string,
   host: string,
-  user?: User
+  user?: User,
 ): boolean {
   if (typeof navigator === "undefined" || !navigator.sendBeacon) {
     console.warn("Beacon API not supported");
     return false;
   }
 
-  const standardizedEvent = standardizeEventData(eventType, data, app, host, user);
+  const standardizedEvent = standardizeEventData(
+    eventType,
+    data,
+    app,
+    host,
+    user,
+  );
   const blob = new Blob([JSON.stringify(standardizedEvent)], {
     type: "application/json",
   });
@@ -74,10 +80,16 @@ export async function sendKafkaEvent(
   data: any,
   app: string,
   host: string,
-  user?: User
+  user?: User,
 ): Promise<string> {
-  const standardizedEvent = standardizeEventData(eventType, data, app, host, user);
-  
+  const standardizedEvent = standardizeEventData(
+    eventType,
+    data,
+    app,
+    host,
+    user,
+  );
+
   try {
     const response = await fetch("/api/metrics/log", {
       method: "POST",
@@ -96,4 +108,4 @@ export async function sendKafkaEvent(
     console.error("Error sending Kafka event:", error);
     return `Error sending event: ${error instanceof Error ? error.message : String(error)}`;
   }
-} 
+}

--- a/apps/app/lib/utils.ts
+++ b/apps/app/lib/utils.ts
@@ -5,10 +5,11 @@ export const sleep = (ms: number) =>
 
 export const isLivepeerEmail = (user: User | null | undefined): boolean => {
   if (!user) return false;
-  
-  const email = user.email?.address || user.google?.email || user.discord?.email;
+
+  const email =
+    user.email?.address || user.google?.email || user.discord?.email;
 
   if (!email) return false;
-  
+
   return email.endsWith("@livepeer.org");
 };


### PR DESCRIPTION
- When user resets camera, the camera access button in onboarding was showing checked. Fixed it now based on permission granted.
- Previously when a user camera was unavailable the Broadcast component would automatically request for the camera. This resulted in permissions being asked even before entering the main experience. This PR fixes that by disallowing Broadcast video if camera permissions are not granted.

- Also fixed formatting in a bunch of files.