### PR TITLE
fix: action icons header to wrap

### DIFF
--- a/apps/app/components/welcome/featured/Dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/Dreamshaper.tsx
@@ -38,7 +38,7 @@ export default function Dreamshaper() {
   const { setLastSubmittedPrompt, setHasSubmittedPrompt } = usePromptStore();
   const { user, authenticated } = usePrivy();
   const { isFullscreen } = useFullscreenStore();
-  const { isMobile } = useMobileStore();
+  const { isMinHeightScreen } = useMobileStore();
   const playerRef = useRef<HTMLDivElement>(null);
 
   usePlayerPositionUpdater(playerRef);
@@ -177,6 +177,7 @@ export default function Dreamshaper() {
               className={cn(
                 "w-full max-w-[calc(min(100%,calc((100vh-16rem)*16/9)))] mx-auto md:aspect-video aspect-square bg-sidebar rounded-2xl overflow-hidden relative",
                 isFullscreen && "w-full h-full max-w-none rounded-none",
+                isMinHeightScreen && "min-w-[596px]",
               )}
             >
               <MainContent />

--- a/apps/app/components/welcome/featured/Dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/Dreamshaper.tsx
@@ -38,7 +38,6 @@ export default function Dreamshaper() {
   const { setLastSubmittedPrompt, setHasSubmittedPrompt } = usePromptStore();
   const { user, authenticated } = usePrivy();
   const { isFullscreen } = useFullscreenStore();
-  const { isMinHeightScreen } = useMobileStore();
   const playerRef = useRef<HTMLDivElement>(null);
 
   usePlayerPositionUpdater(playerRef);
@@ -177,7 +176,7 @@ export default function Dreamshaper() {
               className={cn(
                 "w-full max-w-[calc(min(100%,calc((100vh-16rem)*16/9)))] mx-auto md:aspect-video aspect-square bg-sidebar rounded-2xl overflow-hidden relative",
                 isFullscreen && "w-full h-full max-w-none rounded-none",
-                isMinHeightScreen && "min-w-[596px]",
+                "min-w-[596px]",
               )}
             >
               <MainContent />

--- a/apps/app/components/welcome/featured/Header.tsx
+++ b/apps/app/components/welcome/featured/Header.tsx
@@ -39,6 +39,7 @@ export const Header = () => {
           isFullscreen && "hidden",
           isMobile ? "justify-center px-3 py-3" : "justify-between py-3",
           isMinHeightScreen && "flex-col gap-6",
+          "min-w-[596px]",
         )}
       >
         {isMobile && (
@@ -51,6 +52,7 @@ export const Header = () => {
           className={cn(
             "flex flex-col gap-2",
             isMobile ? "text-center items-center" : "text-left items-start",
+            "",
           )}
         >
           <h1

--- a/apps/app/components/welcome/featured/Header.tsx
+++ b/apps/app/components/welcome/featured/Header.tsx
@@ -25,7 +25,7 @@ const inter = Inter({ subsets: ["latin"] });
 export const Header = () => {
   const { authenticated } = usePrivy();
   const { isFullscreen } = useFullscreenStore();
-  const { isMobile } = useMobileStore();
+  const { isMobile, isMinHeightScreen } = useMobileStore();
   const { stream, streamUrl } = useDreamshaperStore();
   const { live } = useStreamStatus(stream?.id);
   const { hasSubmittedPrompt } = usePromptStore();
@@ -38,6 +38,7 @@ export const Header = () => {
           "flex items-start mt-4 w-full max-w-[calc(min(100%,calc((100vh-16rem)*16/9)))] mx-auto relative",
           isFullscreen && "hidden",
           isMobile ? "justify-center px-3 py-3" : "justify-between py-3",
+          isMinHeightScreen && "flex-col gap-6",
         )}
       >
         {isMobile && (
@@ -79,7 +80,12 @@ export const Header = () => {
 
         {/* Header buttons */}
         {!isMobile && !isFullscreen && (
-          <div className="absolute bottom-3 right-0 flex gap-2">
+          <div
+            className={cn(
+              "absolute bottom-3 right-0 flex gap-2",
+              isMinHeightScreen && "relative",
+            )}
+          >
             <div className="flex items-center gap-2">
               {/* Only show clip button when stream is live */}
               {live && stream?.output_playback_id && streamUrl && (

--- a/apps/app/hooks/useMobileStore.ts
+++ b/apps/app/hooks/useMobileStore.ts
@@ -3,9 +3,11 @@
 import { create } from "zustand";
 
 const MOBILE_BREAKPOINT = 768;
+const HEIGHT_BREAKPOINT = 592;
 
 interface MobileStore {
   isMobile: boolean;
+  isMinHeightScreen: boolean;
 }
 
 const useMobileStore = create<MobileStore>(set => {
@@ -15,12 +17,19 @@ const useMobileStore = create<MobileStore>(set => {
     if (typeof window === "undefined" || listenerInitialized) return;
 
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const heightMql = window.matchMedia(
+      `(max-height: ${HEIGHT_BREAKPOINT - 1}px)`,
+    );
 
     const onChange = () => {
-      set({ isMobile: window.innerWidth < MOBILE_BREAKPOINT });
+      set({
+        isMobile: window.innerWidth < MOBILE_BREAKPOINT,
+        isMinHeightScreen: window.innerHeight < HEIGHT_BREAKPOINT,
+      });
     };
 
     mql.addEventListener("change", onChange);
+    heightMql.addEventListener("change", onChange);
     onChange();
 
     listenerInitialized = true;
@@ -33,6 +42,8 @@ const useMobileStore = create<MobileStore>(set => {
   return {
     isMobile:
       typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT,
+    isMinHeightScreen:
+      typeof window !== "undefined" && window.innerHeight < HEIGHT_BREAKPOINT,
   };
 });
 


### PR DESCRIPTION
- Previously on short screen or in landscape mode, the action buttons were cluttering the screen. Now wrapping them to below the title.

<img width="1073" alt="image" src="https://github.com/user-attachments/assets/d4a21072-b57b-4c70-bbf6-1baf87f0233e" />
