### PR TITLE
fix: remove videojs fullscreen control

### DIFF
--- a/apps/app/components/welcome/featured/videojs-player.tsx
+++ b/apps/app/components/welcome/featured/videojs-player.tsx
@@ -122,17 +122,13 @@ const VideoJSStyles = () => (
       display: none !important;
     }
 
-    /* Position fullscreen button on the far right */
+    /* Hide fullscreen button */
     .video-js .vjs-fullscreen-control {
-      margin-left: auto;
-      order: 99;
+      display: none !important;
     }
 
-    /* Hide any other controls except volume and fullscreen */
-    .video-js
-      .vjs-control:not(.vjs-volume-panel):not(.vjs-fullscreen-control):not(
-        .vjs-mute-control
-      ) {
+    /* Hide any other controls except volume */
+    .video-js .vjs-control:not(.vjs-volume-panel):not(.vjs-mute-control) {
       display: none !important;
     }
 


### PR DESCRIPTION
- When player fallback to videojs occurs, we have 2 fullscreen toggle button on the screen due to inbuilt videojs control being displayed. This PR aims to remove that.