### PR TITLE
dd: feat: animated bento grid on loading + bento grid updates

### DIFF
--- a/apps/app/app/explore/BentoGrids.tsx
+++ b/apps/app/app/explore/BentoGrids.tsx
@@ -132,7 +132,7 @@ function GridItem({
   className?: string;
 }) {
   return (
-    <div className={cn("relative", className)}>
+    <div className={cn("relative aspect-square lg:min-h-[300px] lg:aspect-auto", className)}>
       <div className="absolute inset-px rounded-xl bg-white"></div>
       <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.xl)+1px)]">
         <OptimizedVideo src={src} clipId={clipId} />

--- a/apps/app/app/explore/BentoGrids.tsx
+++ b/apps/app/app/explore/BentoGrids.tsx
@@ -106,7 +106,7 @@ export function BentoGrids({ initialClips }: BentoGridsProps) {
           );
         })}
 
-        <div ref={loadingRef} className="py-8 text-center">
+        <div ref={loadingRef} className="py-8 text-center relative z-50">
           {loading ? (
             <LoadingSpinner />
           ) : hasMore ? (
@@ -114,6 +114,10 @@ export function BentoGrids({ initialClips }: BentoGridsProps) {
           ) : (
             <NoMoreClipsFooter />
           )}
+          <div
+            aria-hidden="true"
+            className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-gray-50 to-transparent pointer-events-none"
+          />
         </div>
       </div>
     </div>

--- a/apps/app/app/explore/BentoGrids.tsx
+++ b/apps/app/app/explore/BentoGrids.tsx
@@ -138,11 +138,12 @@ function GridItem({
         className,
       )}
     >
-      <div className="absolute inset-px rounded-xl bg-white"></div>
-      <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.xl)+1px)]">
+      <div className="absolute inset-px rounded-xl loading-gradient z-0"></div>
+      <div className="absolute inset-px rounded-xl backdrop-blur-[125px] z-10"></div>
+      <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.xl)+1px)] z-20">
         <OptimizedVideo src={src} clipId={clipId} />
       </div>
-      <div className="pointer-events-none absolute inset-px rounded-xl shadow ring-1 ring-black/5"></div>
+      <div className="pointer-events-none absolute inset-px rounded-xl shadow ring-1 ring-black/5 z-30"></div>
     </div>
   );
 }

--- a/apps/app/app/explore/BentoGrids.tsx
+++ b/apps/app/app/explore/BentoGrids.tsx
@@ -132,7 +132,12 @@ function GridItem({
   className?: string;
 }) {
   return (
-    <div className={cn("relative aspect-square lg:min-h-[300px] lg:aspect-auto", className)}>
+    <div
+      className={cn(
+        "relative aspect-square lg:min-h-[300px] lg:aspect-auto",
+        className,
+      )}
+    >
       <div className="absolute inset-px rounded-xl bg-white"></div>
       <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.xl)+1px)]">
         <OptimizedVideo src={src} clipId={clipId} />

--- a/apps/app/app/explore/OptimizedVideo.tsx
+++ b/apps/app/app/explore/OptimizedVideo.tsx
@@ -67,7 +67,7 @@ export default function OptimizedVideo({
           videoElement.pause();
         }
       },
-      { threshold: 0.7 },
+      { threshold: 0.9 },
     );
 
     playbackObserver.observe(containerRef.current);

--- a/apps/app/app/explore/OptimizedVideo.tsx
+++ b/apps/app/app/explore/OptimizedVideo.tsx
@@ -15,6 +15,7 @@ export default function OptimizedVideo({
 }: OptimizedVideoProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [isNearViewport, setIsNearViewport] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const shortSrc = src.replace(/\.mp4$/, "-short.mp4");
@@ -66,10 +67,14 @@ export default function OptimizedVideo({
             muted
             loop
             playsInline
-            className="size-full object-cover object-top"
+            onLoadedData={() => setIsLoaded(true)}
+            className={cn(
+              "size-full object-cover object-top bg-transparent",
+              !isLoaded && "opacity-0",
+            )}
           />
         ) : (
-          <div className="size-full bg-gray-100" />
+          <div className="size-full bg-transparent" />
         )}
       </QuickviewVideo>
     </div>

--- a/apps/app/app/explore/OptimizedVideo.tsx
+++ b/apps/app/app/explore/OptimizedVideo.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@repo/design-system/lib/utils";
 import { useEffect, useRef, useState } from "react";
 import QuickviewVideo from "./QuickviewVideo";
+import { usePreviewStore } from "@/hooks/usePreviewStore";
 
 interface OptimizedVideoProps {
   src: string;
@@ -17,6 +18,7 @@ export default function OptimizedVideo({
   const [isNearViewport, setIsNearViewport] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const isPreviewOpen = usePreviewStore(state => state.isPreviewOpen);
 
   const shortSrc = src.replace(/\.mp4$/, "-short.mp4");
 
@@ -35,9 +37,25 @@ export default function OptimizedVideo({
     return () => nearObserver.disconnect();
   }, []);
 
+  // Effect to handle preview state changes
   useEffect(() => {
     const videoElement = videoRef.current;
-    if (!videoElement || !containerRef.current || !isNearViewport) return;
+    if (!videoElement) return;
+
+    if (isPreviewOpen) {
+      videoElement.pause();
+    }
+  }, [isPreviewOpen]);
+
+  useEffect(() => {
+    const videoElement = videoRef.current;
+    if (
+      !videoElement ||
+      !containerRef.current ||
+      !isNearViewport ||
+      isPreviewOpen
+    )
+      return;
 
     const playbackObserver = new IntersectionObserver(
       entries => {
@@ -55,7 +73,7 @@ export default function OptimizedVideo({
     playbackObserver.observe(containerRef.current);
 
     return () => playbackObserver.disconnect();
-  }, [isNearViewport]);
+  }, [isNearViewport, isPreviewOpen]);
 
   return (
     <div ref={containerRef} className={cn("size-full", className)}>

--- a/apps/app/app/explore/QuickviewVideo.tsx
+++ b/apps/app/app/explore/QuickviewVideo.tsx
@@ -10,6 +10,7 @@ import { VideoProvider } from "./VideoProvider";
 import { VideoPlayer } from "./VideoPlayer";
 import { getAccessToken } from "@privy-io/react-auth";
 import { handleSessionId } from "@/lib/analytics/mixpanel";
+import { usePreviewStore } from "@/hooks/usePreviewStore";
 
 interface QuickviewVideoProps {
   children: React.ReactNode;
@@ -22,9 +23,13 @@ export default function QuickviewVideo({
   clipId,
   src,
 }: QuickviewVideoProps) {
+  const setIsPreviewOpen = usePreviewStore(state => state.setIsPreviewOpen);
+
   return (
     <Dialog
       onOpenChange={async open => {
+        setIsPreviewOpen(open);
+        
         if (!open) return;
 
         const accessToken = await getAccessToken();
@@ -77,6 +82,7 @@ export default function QuickviewVideo({
             </div>
           </div>
         </DialogHeader>
+
         <div className="w-full h-fit relative z-[100]">
           <VideoProvider src={src}>
             <VideoPlayerWrapper />

--- a/apps/app/app/explore/QuickviewVideo.tsx
+++ b/apps/app/app/explore/QuickviewVideo.tsx
@@ -45,7 +45,7 @@ export default function QuickviewVideo({
     >
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
-        className="h-full max-w-2xl max-h-[90vh] border-none bg-transparent shadow-none overflow-hidden pt-6 pb-12"
+        className="max-h-[90vh] max-w-[70vh] border-none bg-transparent shadow-none pt-6 pb-4"
         overlayClassName="bg-white sm:bg-[rgba(255,255,255,0.98)]"
         displayCloseButton={false}
       >
@@ -83,7 +83,7 @@ export default function QuickviewVideo({
           </div>
         </DialogHeader>
 
-        <div className="w-full h-fit relative z-[100]">
+        <div className="w-full h-fit relative">
           <VideoProvider src={src}>
             <VideoPlayerWrapper />
           </VideoProvider>
@@ -95,7 +95,7 @@ export default function QuickviewVideo({
 
 function VideoPlayerWrapper() {
   return (
-    <div className="absolute -bottom-8 left-0 right-0 md:left-2 md:right-2 z-[999]">
+    <div className="relative w-full">
       <VideoPlayer />
     </div>
   );

--- a/apps/app/app/explore/QuickviewVideo.tsx
+++ b/apps/app/app/explore/QuickviewVideo.tsx
@@ -40,7 +40,7 @@ export default function QuickviewVideo({
     >
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
-        className="h-full max-w-xl max-h-[90vh] border-none bg-transparent shadow-none overflow-y-auto py-12"
+        className="h-full max-w-2xl max-h-[90vh] border-none bg-transparent shadow-none overflow-hidden pt-6 pb-12"
         overlayClassName="bg-white sm:bg-[rgba(255,255,255,0.98)]"
         displayCloseButton={false}
       >
@@ -58,7 +58,6 @@ export default function QuickviewVideo({
                 Vincent Van Gogh
               </h2>
               <div className="flex items-center gap-[15px]">
-                <span className="text-sm text-[#707070]">480p</span>
                 <span className="text-sm text-[#707070]">Mar 31, 8:41 AM</span>
               </div>
             </div>

--- a/apps/app/app/explore/QuickviewVideo.tsx
+++ b/apps/app/app/explore/QuickviewVideo.tsx
@@ -29,7 +29,7 @@ export default function QuickviewVideo({
     <Dialog
       onOpenChange={async open => {
         setIsPreviewOpen(open);
-        
+
         if (!open) return;
 
         const accessToken = await getAccessToken();

--- a/apps/app/app/explore/VideoPlayer.tsx
+++ b/apps/app/app/explore/VideoPlayer.tsx
@@ -34,9 +34,9 @@ export function VideoPlayer() {
   }, [player.currentTime]);
 
   return (
-    <div className="flex items-center gap-6 bg-white px-2 py-2 shadow-sm ring-1 shadow-slate-200/80 ring-slate-900/5 backdrop-blur-xs md:px-4 rounded-b-xl md:rounded-t-xl">
+    <div className="absolute left-0 right-0 bottom-0 translate-y-1/2 z-40">
       <div className="mb-[env(safe-area-inset-bottom)] flex flex-1 flex-col gap-3 overflow-hidden p-1">
-        <div className="flex justify-between gap-6 rounded-xl">
+        <div className="flex justify-between gap-6 rounded-xl bg-white px-2 py-2 shadow-sm ring-1 shadow-slate-200/80 ring-slate-900/5 backdrop-blur-xs md:px-4">
           <div className="flex flex-none items-center gap-4">
             <PlayButton player={player} />
           </div>

--- a/apps/app/app/explore/VideoProvider.tsx
+++ b/apps/app/app/explore/VideoProvider.tsx
@@ -178,24 +178,14 @@ export function VideoProvider({
   );
 
   return (
-    <>
-      <VideoPlayerContext.Provider value={api}>
-        {children}
-      </VideoPlayerContext.Provider>
+    <VideoPlayerContext.Provider value={api}>
       <div className="relative w-full">
-        <div className="relative w-full">
-          <div
-            className="top-0 left-0 w-full aspect-video rounded-t-xl md:rounded-b-xl loading-gradient z-0"
-            style={{ height: 0, paddingBottom: "100%" }}
-          ></div>
-          <div
-            className="top-0 left-0 w-full aspect-video rounded-t-xl md:rounded-b-xl backdrop-blur-[125px] z-10"
-            style={{ position: "absolute", height: 0, paddingBottom: "100%" }}
-          >
-            <div className="absolute inset-0 flex items-center justify-center">
+        <div className="relative w-full aspect-square rounded-xl overflow-hidden bg-zinc-100">
+          {state.duration === 0 && (
+            <div className="absolute inset-0 flex items-center justify-center backdrop-blur-md z-10">
               <LoadingSpinner className="w-8 h-8 text-black" />
             </div>
-          </div>
+          )}
           <video
             ref={playerRef}
             onPlay={() => dispatch({ type: ActionKind.PLAY })}
@@ -223,21 +213,18 @@ export function VideoProvider({
             autoPlay
             playsInline
             loop
-            className="relative w-full rounded-t-xl md:rounded-b-xl z-20"
-            style={{
-              position: "absolute",
-              paddingBottom: "100%",
-              top: 0,
-              zIndex: 10,
-            }}
+            className={cn(
+              "absolute inset-0 w-full h-full object-cover z-0 transition-opacity duration-300",
+              state.duration === 0 ? "opacity-0" : "opacity-100",
+            )}
           />
-          <div
-            className="pointer-events-none absolute top-0 left-0 w-full aspect-video rounded-t-xl md:rounded-b-xl shadow ring-1 ring-black/5 z-30"
-            style={{ height: 0, paddingBottom: "100%" }}
-          ></div>
+        </div>
+
+        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 w-[calc(100%-theme(spacing.8))] z-30">
+          {children}
         </div>
       </div>
-    </>
+    </VideoPlayerContext.Provider>
   );
 }
 

--- a/apps/app/app/explore/VideoProvider.tsx
+++ b/apps/app/app/explore/VideoProvider.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { createContext, useContext, useMemo, useReducer, useRef } from "react";
+import { cn } from "@repo/design-system/lib/utils";
+import LoadingSpinner from "./LoadingSpinner";
 
 interface Video {
   id: number;
@@ -180,35 +182,61 @@ export function VideoProvider({
       <VideoPlayerContext.Provider value={api}>
         {children}
       </VideoPlayerContext.Provider>
-      <video
-        ref={playerRef}
-        onPlay={() => dispatch({ type: ActionKind.PLAY })}
-        onPause={() => dispatch({ type: ActionKind.PAUSE })}
-        onTimeUpdate={event => {
-          dispatch({
-            type: ActionKind.SET_CURRENT_TIME,
-            payload: Math.floor(event.currentTarget.currentTime),
-          });
-        }}
-        onDurationChange={event => {
-          dispatch({
-            type: ActionKind.SET_DURATION,
-            payload: Math.floor(event.currentTarget.duration),
-          });
-        }}
-        onVolumeChange={event => {
-          dispatch({
-            type: ActionKind.SET_VOLUME,
-            payload: event.currentTarget.volume,
-          });
-        }}
-        muted={state.muted}
-        src={src}
-        autoPlay
-        playsInline
-        loop
-        className="w-full rounded-t-xl md:rounded-b-xl z-10"
-      />
+      <div className="relative w-full">
+        <div className="relative w-full">
+          <div
+            className="top-0 left-0 w-full aspect-video rounded-t-xl md:rounded-b-xl loading-gradient z-0"
+            style={{ height: 0, paddingBottom: "100%" }}
+          ></div>
+          <div
+            className="top-0 left-0 w-full aspect-video rounded-t-xl md:rounded-b-xl backdrop-blur-[125px] z-10"
+            style={{ position: "absolute", height: 0, paddingBottom: "100%" }}
+          >
+            <div className="absolute inset-0 flex items-center justify-center">
+              <LoadingSpinner className="w-8 h-8 text-black" />
+            </div>
+          </div>
+          <video
+            ref={playerRef}
+            onPlay={() => dispatch({ type: ActionKind.PLAY })}
+            onPause={() => dispatch({ type: ActionKind.PAUSE })}
+            onTimeUpdate={event => {
+              dispatch({
+                type: ActionKind.SET_CURRENT_TIME,
+                payload: Math.floor(event.currentTarget.currentTime),
+              });
+            }}
+            onDurationChange={event => {
+              dispatch({
+                type: ActionKind.SET_DURATION,
+                payload: Math.floor(event.currentTarget.duration),
+              });
+            }}
+            onVolumeChange={event => {
+              dispatch({
+                type: ActionKind.SET_VOLUME,
+                payload: event.currentTarget.volume,
+              });
+            }}
+            muted={state.muted}
+            src={src}
+            autoPlay
+            playsInline
+            loop
+            className="relative w-full rounded-t-xl md:rounded-b-xl z-20"
+            style={{
+              position: "absolute",
+              paddingBottom: "100%",
+              top: 0,
+              zIndex: 10,
+            }}
+          />
+          <div
+            className="pointer-events-none absolute top-0 left-0 w-full aspect-video rounded-t-xl md:rounded-b-xl shadow ring-1 ring-black/5 z-30"
+            style={{ height: 0, paddingBottom: "100%" }}
+          ></div>
+        </div>
+      </div>
     </>
   );
 }

--- a/apps/app/app/explore/VideoProvider.tsx
+++ b/apps/app/app/explore/VideoProvider.tsx
@@ -180,9 +180,9 @@ export function VideoProvider({
   return (
     <VideoPlayerContext.Provider value={api}>
       <div className="relative w-full">
-        <div className="relative w-full aspect-square rounded-xl overflow-hidden bg-zinc-100">
+        <div className="relative w-full aspect-square rounded-xl overflow-hidden bg-zinc-100 loading-gradient">
           {state.duration === 0 && (
-            <div className="absolute inset-0 flex items-center justify-center backdrop-blur-md z-10">
+            <div className="absolute inset-0 flex items-center justify-center backdrop-blur-[125px] z-10">
               <LoadingSpinner className="w-8 h-8 text-black" />
             </div>
           )}

--- a/apps/app/hooks/usePreviewStore.ts
+++ b/apps/app/hooks/usePreviewStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface PreviewStore {
+  isPreviewOpen: boolean;
+  setIsPreviewOpen: (isOpen: boolean) => void;
+}
+
+export const usePreviewStore = create<PreviewStore>(set => ({
+  isPreviewOpen: false,
+  setIsPreviewOpen: (isOpen: boolean) => set({ isPreviewOpen: isOpen }),
+}));

--- a/packages/design-system/styles/globals.css
+++ b/packages/design-system/styles/globals.css
@@ -348,3 +348,24 @@
   opacity: 0.3;
   z-index: 1;
 }
+
+@keyframes loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.loading-gradient {
+  background: linear-gradient(40deg, 
+    #ffffff 0%,
+    #f3f4f6 25%,
+    #b2cad1 50%,
+    #f3f4f6 75%,
+    #ffffff 100%
+  );
+  background-size: 200% 100%;
+  animation: loading 5s linear infinite;
+}


### PR DESCRIPTION

## Changes

- Animated loading background
- Same animation for preview
- Bigger preview playback
- Increased threshold for video cleanup
- Freeze Bento videos when preview is opened

<video src="https://github.com/user-attachments/assets/8cd25163-8b4c-4cb1-a4db-6edd96f240db" controls width="600"></video>
<video src="https://github.com/user-attachments/assets/2fdf12b2-4876-495e-9cc1-3f537034bad4" controls width="600"></video>

