### PR TITLE
dd: feat: clips priority for admin & bento grid

### DIFF
--- a/apps/app/app/admin/clips/page.tsx
+++ b/apps/app/app/admin/clips/page.tsx
@@ -76,17 +76,25 @@ export default function ClipsAdminPage() {
   const handleSaveClip = async (
     updatedClip: Partial<Clip> & { id: number },
   ) => {
-    if (updatedClip.priority !== null && updatedClip.priority !== undefined && updatedClip.priority > 0) {
+    if (
+      updatedClip.priority !== null &&
+      updatedClip.priority !== undefined &&
+      updatedClip.priority > 0
+    ) {
       const conflictingClip = clips.find(
         c => c.id !== updatedClip.id && c.priority === updatedClip.priority,
       );
 
       if (conflictingClip) {
-         throw new Error(
-            `Priority ${updatedClip.priority} is already assigned to Clip #${conflictingClip.id} ("${conflictingClip.prompt?.substring(0, 30)}..."). Please choose a different priority or remove it from the other clip first.`
-         );
+        throw new Error(
+          `Priority ${updatedClip.priority} is already assigned to Clip #${conflictingClip.id} ("${conflictingClip.prompt?.substring(0, 30)}..."). Please choose a different priority or remove it from the other clip first.`,
+        );
       }
-    } else if (updatedClip.priority !== null && updatedClip.priority !== undefined && updatedClip.priority <= 0) {
+    } else if (
+      updatedClip.priority !== null &&
+      updatedClip.priority !== undefined &&
+      updatedClip.priority <= 0
+    ) {
       throw new Error("Priority must be a positive number.");
     }
 
@@ -135,14 +143,13 @@ export default function ClipsAdminPage() {
       if (!response.ok) {
         const errorData = await response.json();
         console.error("Clip update error:", errorData);
-        throw new Error(errorData.error || "Failed to update clip"); 
+        throw new Error(errorData.error || "Failed to update clip");
       }
 
       await fetchClips();
-
     } catch (err) {
       console.error("Error in handleSaveClip:", err);
-      throw err; 
+      throw err;
     }
   };
 

--- a/apps/app/app/admin/clips/page.tsx
+++ b/apps/app/app/admin/clips/page.tsx
@@ -76,6 +76,20 @@ export default function ClipsAdminPage() {
   const handleSaveClip = async (
     updatedClip: Partial<Clip> & { id: number },
   ) => {
+    if (updatedClip.priority !== null && updatedClip.priority !== undefined && updatedClip.priority > 0) {
+      const conflictingClip = clips.find(
+        c => c.id !== updatedClip.id && c.priority === updatedClip.priority,
+      );
+
+      if (conflictingClip) {
+         throw new Error(
+            `Priority ${updatedClip.priority} is already assigned to Clip #${conflictingClip.id} ("${conflictingClip.prompt?.substring(0, 30)}..."). Please choose a different priority or remove it from the other clip first.`
+         );
+      }
+    } else if (updatedClip.priority !== null && updatedClip.priority !== undefined && updatedClip.priority <= 0) {
+      throw new Error("Priority must be a positive number.");
+    }
+
     try {
       console.log("Received updatedClip:", updatedClip);
 
@@ -121,13 +135,14 @@ export default function ClipsAdminPage() {
       if (!response.ok) {
         const errorData = await response.json();
         console.error("Clip update error:", errorData);
-        throw new Error(errorData.error || "Failed to update clip");
+        throw new Error(errorData.error || "Failed to update clip"); 
       }
 
       await fetchClips();
+
     } catch (err) {
       console.error("Error in handleSaveClip:", err);
-      throw err;
+      throw err; 
     }
   };
 

--- a/apps/app/app/api/admin/clips/route.ts
+++ b/apps/app/app/api/admin/clips/route.ts
@@ -2,7 +2,24 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { clips as clipsTable, users } from "@/lib/db/schema";
 import { requireAdminAuth } from "@/app/api/admin/auth";
-import { eq, desc, isNull } from "drizzle-orm";
+import { eq, isNull, isNotNull, asc, and } from "drizzle-orm";
+
+type AdminFetchedClip = {
+  id: number;
+  video_url: string;
+  video_title: string | null;
+  thumbnail_url: string | null;
+  author_user_id: string;
+  source_clip_id: number | null;
+  prompt: string;
+  priority: number | null;
+  created_at: Date;
+  deleted_at: Date | null;
+  author: {
+    id: string;
+    name: string | null;
+  } | null; 
+};
 
 export async function GET(request: Request) {
   try {
@@ -12,8 +29,7 @@ export async function GET(request: Request) {
       return authResponse;
     }
 
-    const clips = await db
-      .select({
+    const selectFields = {
         id: clipsTable.id,
         video_url: clipsTable.video_url,
         video_title: clipsTable.video_title,
@@ -28,13 +44,73 @@ export async function GET(request: Request) {
           id: users.id,
           name: users.name,
         },
-      })
-      .from(clipsTable)
-      .leftJoin(users, eq(clipsTable.author_user_id, users.id))
-      .where(isNull(clipsTable.deleted_at))
-      .orderBy(desc(clipsTable.created_at));
+      };
 
-    return NextResponse.json(clips);
+    const prioritizedClips = (await db
+      .select(selectFields)
+      .from(clipsTable)
+      .leftJoin(users, eq(clipsTable.author_user_id, users.id)) // Left join for author
+      .where(and(isNull(clipsTable.deleted_at), isNotNull(clipsTable.priority)))
+      .orderBy(asc(clipsTable.priority))) as AdminFetchedClip[];
+
+    const nonPrioritizedClips = (await db
+      .select(selectFields)
+      .from(clipsTable)
+      .leftJoin(users, eq(clipsTable.author_user_id, users.id)) // Left join for author
+      .where(and(isNull(clipsTable.deleted_at), isNull(clipsTable.priority)))
+      .orderBy(asc(clipsTable.created_at))) as AdminFetchedClip[]; // Older first
+
+    const finalClips: (AdminFetchedClip | null)[] = [];
+    const priorityMap = new Map<number, AdminFetchedClip>();
+    let maxPriority = 0;
+
+    for (const clip of prioritizedClips) {
+      if (clip.priority !== null && clip.priority > 0) {
+        const position = clip.priority;
+        if (position > maxPriority) {
+          maxPriority = position;
+        }
+         if (priorityMap.has(position)) {
+           console.warn(`[Admin API] Duplicate priority ${position} found for clips ${priorityMap.get(position)?.id} and ${clip.id}. Using clip ${clip.id}.`);
+        }
+        priorityMap.set(position, clip);
+      } else {
+         console.warn(`[Admin API] Clip ${clip.id} has invalid priority: ${clip.priority}. Ignoring priority.`);
+         nonPrioritizedClips.push(clip);
+         nonPrioritizedClips.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+      }
+    }
+
+    const initialLength = Math.max(maxPriority, nonPrioritizedClips.length + priorityMap.size)
+    for (let i = 0; i < initialLength; i++) {
+       finalClips[i] = null
+    }
+
+     for (const [position, clip] of priorityMap.entries()) {
+        if(position -1 >= 0) {
+             if (position - 1 >= finalClips.length) {
+                 for (let k = finalClips.length; k <= position - 1; k++) {
+                     finalClips[k] = null;
+                 }
+             }
+             finalClips[position - 1] = clip;
+        }
+    }
+
+    let nonPrioritizedIndex = 0;
+    for (let i = 0; i < finalClips.length && nonPrioritizedIndex < nonPrioritizedClips.length; i++) {
+      if (finalClips[i] === null) {
+        finalClips[i] = nonPrioritizedClips[nonPrioritizedIndex++];
+      }
+    }
+
+    while (nonPrioritizedIndex < nonPrioritizedClips.length) {
+      finalClips.push(nonPrioritizedClips[nonPrioritizedIndex++]);
+    }
+
+    const finalNonNullClips = finalClips.filter(clip => clip !== null) as AdminFetchedClip[];
+
+    return NextResponse.json(finalNonNullClips);
   } catch (error) {
     console.error("Failed to fetch clips:", error);
     return NextResponse.json(

--- a/apps/app/app/api/clips/route.ts
+++ b/apps/app/app/api/clips/route.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { eq, sql, isNull, isNotNull, asc, and } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import {
@@ -7,16 +7,34 @@ import {
   clipSlugs as clipSlugsTable,
 } from "@/lib/db/schema";
 
+type FetchedClip = {
+  id: number;
+  video_url: string;
+  video_title: string | null;
+  created_at: Date;
+  author_name: string | null;
+  remix_count: number;
+  slug: string | null;
+  priority: number | null; 
+};
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const page = Number(searchParams.get("page") || "0");
   const limit = Number(searchParams.get("limit") || "12");
 
-  if (limit > 100) {
+  if (limit > 100 || limit <= 0) { 
     return NextResponse.json(
       {
-        error: "Limit cannot exceed 100",
+        error: "Limit must be between 1 and 100",
       },
+      { status: 400 },
+    );
+  }
+
+  if (page < 0) { 
+    return NextResponse.json(
+      { error: "Page cannot be negative" },
       { status: 400 },
     );
   }
@@ -24,53 +42,98 @@ export async function GET(request: Request) {
   const offset = page * limit;
 
   try {
-    const clips = await db
-      .select({
-        id: clipsTable.id,
-        video_url: clipsTable.video_url,
-        video_title: clipsTable.video_title,
-        created_at: clipsTable.created_at,
-        author_name: usersTable.name,
-        remix_count: sql<number>`(
+    const selectFields = {
+      id: clipsTable.id,
+      video_url: clipsTable.video_url,
+      video_title: clipsTable.video_title,
+      created_at: clipsTable.created_at,
+      author_name: usersTable.name,
+      remix_count: sql<number>`(
             SELECT count(*)
             FROM ${clipsTable} AS derived_clips
             WHERE derived_clips.source_clip_id = ${clipsTable.id}
           )`.mapWith(Number),
-        slug: clipSlugsTable.slug,
-      })
+      slug: clipSlugsTable.slug,
+      priority: clipsTable.priority, 
+    };
+
+    const prioritizedClips = (await db
+      .select(selectFields)
       .from(clipsTable)
       .innerJoin(usersTable, eq(clipsTable.author_user_id, usersTable.id))
       .leftJoin(clipSlugsTable, eq(clipsTable.id, clipSlugsTable.clip_id))
-      .orderBy(clipsTable.created_at)
-      .limit(limit)
-      .offset(offset);
+      .where(and(isNull(clipsTable.deleted_at), isNotNull(clipsTable.priority))) 
+      .orderBy(asc(clipsTable.priority))) as FetchedClip[]; 
 
-    // TODO: pass next page clips also
-    const nextPageClips = await db
-      .select({
-        id: clipsTable.id,
-        video_url: clipsTable.video_url,
-        video_title: clipsTable.video_title,
-        created_at: clipsTable.created_at,
-        author_name: usersTable.name,
-        remix_count: sql<number>`(
-          SELECT count(*)
-          FROM ${clipsTable} AS derived_clips
-          WHERE derived_clips.source_clip_id = ${clipsTable.id}
-        )`.mapWith(Number),
-        slug: clipSlugsTable.slug,
-      })
+    const nonPrioritizedClips = (await db
+      .select(selectFields)
       .from(clipsTable)
       .innerJoin(usersTable, eq(clipsTable.author_user_id, usersTable.id))
       .leftJoin(clipSlugsTable, eq(clipsTable.id, clipSlugsTable.clip_id))
-      .orderBy(clipsTable.created_at)
-      .limit(1)
-      .offset(offset + limit);
+      .where(and(isNull(clipsTable.deleted_at), isNull(clipsTable.priority))) 
+      .orderBy(asc(clipsTable.created_at))) as FetchedClip[]; 
 
-    const hasMore = nextPageClips.length > 0;
+    const finalClips: (FetchedClip | null)[] = [];
+    const priorityMap = new Map<number, FetchedClip>();
+    let maxPriority = 0;
+
+    for (const clip of prioritizedClips) {
+      if (clip.priority !== null && clip.priority > 0) {
+        const position = clip.priority;
+        if (position > maxPriority) {
+          maxPriority = position;
+        }
+        if (priorityMap.has(position)) {
+           console.warn(`Duplicate priority ${position} found for clips ${priorityMap.get(position)?.id} and ${clip.id}. Using clip ${clip.id}.`);
+        }
+        priorityMap.set(position, clip);
+      } else {
+        console.warn(`Clip ${clip.id} has invalid priority: ${clip.priority}. Ignoring priority.`);
+        nonPrioritizedClips.push(clip);
+        nonPrioritizedClips.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+
+      }
+    }
+
+
+    const initialLength = Math.max(maxPriority, nonPrioritizedClips.length + priorityMap.size)
+    for (let i = 0; i < initialLength; i++) {
+       finalClips[i] = null 
+    }
+
+
+    for (const [position, clip] of priorityMap.entries()) {
+        if(position -1 >= 0) { 
+             if (position - 1 >= finalClips.length) {
+                 for (let k = finalClips.length; k <= position - 1; k++) {
+                     finalClips[k] = null;
+                 }
+             }
+             finalClips[position - 1] = clip;
+        }
+    }
+
+
+    let nonPrioritizedIndex = 0;
+    for (let i = 0; i < finalClips.length && nonPrioritizedIndex < nonPrioritizedClips.length; i++) {
+      if (finalClips[i] === null) {
+        finalClips[i] = nonPrioritizedClips[nonPrioritizedIndex++];
+      }
+    }
+
+    while (nonPrioritizedIndex < nonPrioritizedClips.length) {
+      finalClips.push(nonPrioritizedClips[nonPrioritizedIndex++]);
+    }
+
+    const finalNonNullClips = finalClips.filter(clip => clip !== null) as FetchedClip[];
+
+    const paginatedClips = finalNonNullClips.slice(offset, offset + limit);
+
+    const totalClips = finalNonNullClips.length;
+    const hasMore = offset + limit < totalClips;
 
     return NextResponse.json({
-      clips,
+      clips: paginatedClips,
       hasMore,
     });
   } catch (error) {

--- a/apps/app/app/explore/BentoGrids.tsx
+++ b/apps/app/app/explore/BentoGrids.tsx
@@ -38,7 +38,7 @@ export function BentoGrids({ initialClips }: BentoGridsProps) {
   const { isPreviewOpen } = usePreviewStore();
 
   const searchParams = useSearchParams();
-  const isDebug = searchParams.has('debug');
+  const isDebug = searchParams.has("debug");
 
   useEffect(() => {
     if (!initialFetchDone.current && initialClips.length === 0) {

--- a/apps/app/app/explore/hooks/useClipsFetcher.ts
+++ b/apps/app/app/explore/hooks/useClipsFetcher.ts
@@ -9,6 +9,7 @@ export type Clip = {
   author_name: string | null;
   remix_count: number;
   slug: string | null;
+  priority: number | null;
 };
 
 export default function useClipsFetcher(initialClips: Clip[] = []) {

--- a/apps/app/app/explore/page.tsx
+++ b/apps/app/app/explore/page.tsx
@@ -4,13 +4,24 @@ import {
   users as usersTable,
   clipSlugs as clipSlugsTable,
 } from "@/lib/db/schema";
-import { eq, sql } from "drizzle-orm";
+import { eq, sql, isNull, isNotNull, asc, and } from "drizzle-orm";
 import { BentoGrids } from "./BentoGrids";
 import Header from "./Header";
 
+type InitialFetchedClip = {
+  id: number;
+  video_url: string;
+  video_title: string | null;
+  created_at: Date;
+  prompt: string;
+  remix_count: number;
+  author_name: string | null;
+  slug: string | null;
+  priority: number | null; 
+};
+
 async function getInitialClips() {
-  const clips = await db
-    .select({
+    const selectFields = {
       id: clipsTable.id,
       video_url: clipsTable.video_url,
       video_title: clipsTable.video_title,
@@ -23,23 +34,88 @@ async function getInitialClips() {
         )`.mapWith(Number),
       author_name: usersTable.name,
       slug: clipSlugsTable.slug,
-    })
-    .from(clipsTable)
-    .innerJoin(usersTable, eq(clipsTable.author_user_id, usersTable.id))
-    .leftJoin(clipSlugsTable, eq(clipsTable.id, clipSlugsTable.clip_id))
-    .orderBy(clipsTable.created_at)
-    .limit(12);
+      priority: clipsTable.priority, 
+    };
 
-  return clips.map(clip => ({
-    id: String(clip.id),
-    video_url: clip.video_url,
-    video_title: clip.video_title,
-    created_at: clip.created_at.toISOString(),
-    prompt: clip.prompt,
-    author_name: clip.author_name,
-    remix_count: clip.remix_count,
-    slug: clip.slug,
-  }));
+   const prioritizedClips = (await db
+     .select(selectFields)
+     .from(clipsTable)
+     .innerJoin(usersTable, eq(clipsTable.author_user_id, usersTable.id))
+     .leftJoin(clipSlugsTable, eq(clipsTable.id, clipSlugsTable.clip_id))
+     .where(and(isNull(clipsTable.deleted_at), isNotNull(clipsTable.priority)))
+     .orderBy(asc(clipsTable.priority))) as InitialFetchedClip[];
+
+   const nonPrioritizedClips = (await db
+     .select(selectFields)
+     .from(clipsTable)
+     .innerJoin(usersTable, eq(clipsTable.author_user_id, usersTable.id))
+     .leftJoin(clipSlugsTable, eq(clipsTable.id, clipSlugsTable.clip_id))
+     .where(and(isNull(clipsTable.deleted_at), isNull(clipsTable.priority)))
+     .orderBy(asc(clipsTable.created_at))) as InitialFetchedClip[]; // Older first
+
+    const finalClips: (InitialFetchedClip | null)[] = [];
+    const priorityMap = new Map<number, InitialFetchedClip>();
+    let maxPriority = 0;
+
+    for (const clip of prioritizedClips) {
+      if (clip.priority !== null && clip.priority > 0) {
+        const position = clip.priority;
+        if (position > maxPriority) {
+          maxPriority = position;
+        }
+         if (priorityMap.has(position)) {
+           console.warn(`[getInitialClips] Duplicate priority ${position} found for clips ${priorityMap.get(position)?.id} and ${clip.id}. Using clip ${clip.id}.`);
+        }
+        priorityMap.set(position, clip);
+      } else {
+         console.warn(`[getInitialClips] Clip ${clip.id} has invalid priority: ${clip.priority}. Ignoring priority.`);
+         nonPrioritizedClips.push(clip);
+         nonPrioritizedClips.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+      }
+    }
+
+    const initialLength = Math.max(maxPriority, nonPrioritizedClips.length + priorityMap.size)
+    for (let i = 0; i < initialLength; i++) {
+       finalClips[i] = null
+    }
+
+     for (const [position, clip] of priorityMap.entries()) {
+        if(position -1 >= 0) {
+             if (position - 1 >= finalClips.length) {
+                 for (let k = finalClips.length; k <= position - 1; k++) {
+                     finalClips[k] = null;
+                 }
+             }
+             finalClips[position - 1] = clip;
+        }
+    }
+
+    let nonPrioritizedIndex = 0;
+    for (let i = 0; i < finalClips.length && nonPrioritizedIndex < nonPrioritizedClips.length; i++) {
+      if (finalClips[i] === null) {
+        finalClips[i] = nonPrioritizedClips[nonPrioritizedIndex++];
+      }
+    }
+
+    while (nonPrioritizedIndex < nonPrioritizedClips.length) {
+      finalClips.push(nonPrioritizedClips[nonPrioritizedIndex++]);
+    }
+
+    const finalNonNullClips = finalClips.filter(clip => clip !== null) as InitialFetchedClip[];
+
+    const initialSortedClips = finalNonNullClips.slice(0, 12);
+
+    return initialSortedClips.map(clip => ({
+      id: String(clip.id),
+      video_url: clip.video_url,
+      video_title: clip.video_title,
+      created_at: clip.created_at.toISOString(), 
+      prompt: clip.prompt,
+      author_name: clip.author_name,
+      remix_count: clip.remix_count,
+      slug: clip.slug,
+      priority: clip.priority, 
+    }));
 }
 
 export default async function Explore() {

--- a/apps/app/app/explore/page.tsx
+++ b/apps/app/app/explore/page.tsx
@@ -17,105 +17,120 @@ type InitialFetchedClip = {
   remix_count: number;
   author_name: string | null;
   slug: string | null;
-  priority: number | null; 
+  priority: number | null;
 };
 
 async function getInitialClips() {
-    const selectFields = {
-      id: clipsTable.id,
-      video_url: clipsTable.video_url,
-      video_title: clipsTable.video_title,
-      created_at: clipsTable.created_at,
-      prompt: clipsTable.prompt,
-      remix_count: sql<number>`(
+  const selectFields = {
+    id: clipsTable.id,
+    video_url: clipsTable.video_url,
+    video_title: clipsTable.video_title,
+    created_at: clipsTable.created_at,
+    prompt: clipsTable.prompt,
+    remix_count: sql<number>`(
           SELECT count(*) 
           FROM ${clipsTable} AS remixed_clips
           WHERE remixed_clips.source_clip_id = ${clipsTable.id}
         )`.mapWith(Number),
-      author_name: usersTable.name,
-      slug: clipSlugsTable.slug,
-      priority: clipsTable.priority, 
-    };
+    author_name: usersTable.name,
+    slug: clipSlugsTable.slug,
+    priority: clipsTable.priority,
+  };
 
-   const prioritizedClips = (await db
-     .select(selectFields)
-     .from(clipsTable)
-     .innerJoin(usersTable, eq(clipsTable.author_user_id, usersTable.id))
-     .leftJoin(clipSlugsTable, eq(clipsTable.id, clipSlugsTable.clip_id))
-     .where(and(isNull(clipsTable.deleted_at), isNotNull(clipsTable.priority)))
-     .orderBy(asc(clipsTable.priority))) as InitialFetchedClip[];
+  const prioritizedClips = (await db
+    .select(selectFields)
+    .from(clipsTable)
+    .innerJoin(usersTable, eq(clipsTable.author_user_id, usersTable.id))
+    .leftJoin(clipSlugsTable, eq(clipsTable.id, clipSlugsTable.clip_id))
+    .where(and(isNull(clipsTable.deleted_at), isNotNull(clipsTable.priority)))
+    .orderBy(asc(clipsTable.priority))) as InitialFetchedClip[];
 
-   const nonPrioritizedClips = (await db
-     .select(selectFields)
-     .from(clipsTable)
-     .innerJoin(usersTable, eq(clipsTable.author_user_id, usersTable.id))
-     .leftJoin(clipSlugsTable, eq(clipsTable.id, clipSlugsTable.clip_id))
-     .where(and(isNull(clipsTable.deleted_at), isNull(clipsTable.priority)))
-     .orderBy(asc(clipsTable.created_at))) as InitialFetchedClip[]; // Older first
+  const nonPrioritizedClips = (await db
+    .select(selectFields)
+    .from(clipsTable)
+    .innerJoin(usersTable, eq(clipsTable.author_user_id, usersTable.id))
+    .leftJoin(clipSlugsTable, eq(clipsTable.id, clipSlugsTable.clip_id))
+    .where(and(isNull(clipsTable.deleted_at), isNull(clipsTable.priority)))
+    .orderBy(asc(clipsTable.created_at))) as InitialFetchedClip[]; // Older first
 
-    const finalClips: (InitialFetchedClip | null)[] = [];
-    const priorityMap = new Map<number, InitialFetchedClip>();
-    let maxPriority = 0;
+  const finalClips: (InitialFetchedClip | null)[] = [];
+  const priorityMap = new Map<number, InitialFetchedClip>();
+  let maxPriority = 0;
 
-    for (const clip of prioritizedClips) {
-      if (clip.priority !== null && clip.priority > 0) {
-        const position = clip.priority;
-        if (position > maxPriority) {
-          maxPriority = position;
-        }
-         if (priorityMap.has(position)) {
-           console.warn(`[getInitialClips] Duplicate priority ${position} found for clips ${priorityMap.get(position)?.id} and ${clip.id}. Using clip ${clip.id}.`);
-        }
-        priorityMap.set(position, clip);
-      } else {
-         console.warn(`[getInitialClips] Clip ${clip.id} has invalid priority: ${clip.priority}. Ignoring priority.`);
-         nonPrioritizedClips.push(clip);
-         nonPrioritizedClips.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+  for (const clip of prioritizedClips) {
+    if (clip.priority !== null && clip.priority > 0) {
+      const position = clip.priority;
+      if (position > maxPriority) {
+        maxPriority = position;
       }
-    }
-
-    const initialLength = Math.max(maxPriority, nonPrioritizedClips.length + priorityMap.size)
-    for (let i = 0; i < initialLength; i++) {
-       finalClips[i] = null
-    }
-
-     for (const [position, clip] of priorityMap.entries()) {
-        if(position -1 >= 0) {
-             if (position - 1 >= finalClips.length) {
-                 for (let k = finalClips.length; k <= position - 1; k++) {
-                     finalClips[k] = null;
-                 }
-             }
-             finalClips[position - 1] = clip;
-        }
-    }
-
-    let nonPrioritizedIndex = 0;
-    for (let i = 0; i < finalClips.length && nonPrioritizedIndex < nonPrioritizedClips.length; i++) {
-      if (finalClips[i] === null) {
-        finalClips[i] = nonPrioritizedClips[nonPrioritizedIndex++];
+      if (priorityMap.has(position)) {
+        console.warn(
+          `[getInitialClips] Duplicate priority ${position} found for clips ${priorityMap.get(position)?.id} and ${clip.id}. Using clip ${clip.id}.`,
+        );
       }
+      priorityMap.set(position, clip);
+    } else {
+      console.warn(
+        `[getInitialClips] Clip ${clip.id} has invalid priority: ${clip.priority}. Ignoring priority.`,
+      );
+      nonPrioritizedClips.push(clip);
+      nonPrioritizedClips.sort(
+        (a, b) => a.created_at.getTime() - b.created_at.getTime(),
+      );
     }
+  }
 
-    while (nonPrioritizedIndex < nonPrioritizedClips.length) {
-      finalClips.push(nonPrioritizedClips[nonPrioritizedIndex++]);
+  const initialLength = Math.max(
+    maxPriority,
+    nonPrioritizedClips.length + priorityMap.size,
+  );
+  for (let i = 0; i < initialLength; i++) {
+    finalClips[i] = null;
+  }
+
+  for (const [position, clip] of priorityMap.entries()) {
+    if (position - 1 >= 0) {
+      if (position - 1 >= finalClips.length) {
+        for (let k = finalClips.length; k <= position - 1; k++) {
+          finalClips[k] = null;
+        }
+      }
+      finalClips[position - 1] = clip;
     }
+  }
 
-    const finalNonNullClips = finalClips.filter(clip => clip !== null) as InitialFetchedClip[];
+  let nonPrioritizedIndex = 0;
+  for (
+    let i = 0;
+    i < finalClips.length && nonPrioritizedIndex < nonPrioritizedClips.length;
+    i++
+  ) {
+    if (finalClips[i] === null) {
+      finalClips[i] = nonPrioritizedClips[nonPrioritizedIndex++];
+    }
+  }
 
-    const initialSortedClips = finalNonNullClips.slice(0, 12);
+  while (nonPrioritizedIndex < nonPrioritizedClips.length) {
+    finalClips.push(nonPrioritizedClips[nonPrioritizedIndex++]);
+  }
 
-    return initialSortedClips.map(clip => ({
-      id: String(clip.id),
-      video_url: clip.video_url,
-      video_title: clip.video_title,
-      created_at: clip.created_at.toISOString(), 
-      prompt: clip.prompt,
-      author_name: clip.author_name,
-      remix_count: clip.remix_count,
-      slug: clip.slug,
-      priority: clip.priority, 
-    }));
+  const finalNonNullClips = finalClips.filter(
+    clip => clip !== null,
+  ) as InitialFetchedClip[];
+
+  const initialSortedClips = finalNonNullClips.slice(0, 12);
+
+  return initialSortedClips.map(clip => ({
+    id: String(clip.id),
+    video_url: clip.video_url,
+    video_title: clip.video_title,
+    created_at: clip.created_at.toISOString(),
+    prompt: clip.prompt,
+    author_name: clip.author_name,
+    remix_count: clip.remix_count,
+    slug: clip.slug,
+    priority: clip.priority,
+  }));
 }
 
 export default async function Explore() {


### PR DESCRIPTION
- Consider priority when displaying clips, both in admin and grid. The priority is the specified position in the grid or table
- Handle this for the pagination as well
- added a ?debug flag to the explore page that shows the index number of clips, useful when editing clip priorities
- Throw an error if you try to assign a priority number to a clip and that position is already occupied by another prioritized clip
- Handle priority gaps