### PR TITLE
dd: feat: prettier + restore css changes + better buttons

### DIFF
--- a/apps/app/app/(main)/hooks/useClipsFetcher.ts
+++ b/apps/app/app/(main)/hooks/useClipsFetcher.ts
@@ -49,6 +49,7 @@ export default function useClipsFetcher(initialClips: Clip[] = []) {
               : new Date().toISOString(),
             video_title: clip.video_title,
             video_url: clip.video_url,
+            prompt: clip.prompt || "",
             author_name: clip.author_name || null,
             remix_count: clip.remix_count,
             slug: clip.slug,

--- a/apps/app/app/api/clips/route.ts
+++ b/apps/app/app/api/clips/route.ts
@@ -57,6 +57,7 @@ export async function GET(request: Request) {
       video_title: clipsTable.video_title,
       created_at: clipsTable.created_at,
       author_name: usersTable.name,
+      prompt: clipsTable.prompt,
       remix_count: sql<number>`(
             SELECT count(*)
             FROM ${clipsTable} AS derived_clips

--- a/apps/app/app/api/metrics/beacon/route.ts
+++ b/apps/app/app/api/metrics/beacon/route.ts
@@ -43,22 +43,23 @@ export async function POST(request: NextRequest) {
     const appConfig = getAppConfig(request.nextUrl.searchParams);
     const ip =
       appConfig.environment === "dev"
-        ? "development.fake.ip" 
+        ? "development.fake.ip"
         : forwardedFor
           ? forwardedFor.split(",")[0].trim()
           : "";
-    
+
     const userAgent = request.headers.get("user-agent") || "";
 
-    const geoData = ip && ip !== "127.0.0.1" && ip !== "::1" 
-      ? await getGeoData(ip) 
-      : {
-          city: "",
-          region: "",
-          country: "",
-          latitude: "",
-          longitude: "",
-        };
+    const geoData =
+      ip && ip !== "127.0.0.1" && ip !== "::1"
+        ? await getGeoData(ip)
+        : {
+            city: "",
+            region: "",
+            country: "",
+            latitude: "",
+            longitude: "",
+          };
 
     const { viewer_info, broadcaster_info, ...cleanData } = data;
 

--- a/apps/app/app/api/metrics/log/route.ts
+++ b/apps/app/app/api/metrics/log/route.ts
@@ -33,7 +33,7 @@ export async function POST(request: NextRequest) {
     if (!eventType || !data || !app || !host) {
       return NextResponse.json(
         { error: "Missing required fields" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -45,18 +45,19 @@ export async function POST(request: NextRequest) {
         : forwardedFor
           ? forwardedFor.split(",")[0].trim()
           : "";
-    
+
     const userAgent = request.headers.get("user-agent") || "";
 
-    const geoData = ip && ip !== "127.0.0.1" && ip !== "::1" 
-      ? await getGeoData(ip) 
-      : {
-          city: "",
-          region: "",
-          country: "",
-          latitude: "",
-          longitude: "",
-        };
+    const geoData =
+      ip && ip !== "127.0.0.1" && ip !== "::1"
+        ? await getGeoData(ip)
+        : {
+            city: "",
+            region: "",
+            country: "",
+            latitude: "",
+            longitude: "",
+          };
 
     const { viewer_info, broadcaster_info, ...cleanData } = data;
 
@@ -77,7 +78,7 @@ export async function POST(request: NextRequest) {
     console.error("Error processing Kafka request:", error);
     return NextResponse.json(
       { error: "Failed to process Kafka request" },
-      { status: 500 }
+      { status: 500 },
     );
   }
-} 
+}

--- a/apps/app/components/playground/broadcast.tsx
+++ b/apps/app/components/playground/broadcast.tsx
@@ -54,7 +54,7 @@ const StatusMonitor = () => {
           },
           "daydream",
           "server",
-          user || undefined
+          user || undefined,
         );
       };
 
@@ -133,13 +133,15 @@ export function BroadcastWithControls({ className }: { className?: string }) {
       video={true}
       aspectRatio={16 / 9}
       ingestUrl={ingestUrl}
-      {...{iceServers: {
-        urls: [
-          "stun:stun.l.google.com:19302",
-          "stun:stun1.l.google.com:19302",
-          "stun:stun.cloudflare.com:3478",
-        ],
-      }} as any}
+      {...({
+        iceServers: {
+          urls: [
+            "stun:stun.l.google.com:19302",
+            "stun:stun1.l.google.com:19302",
+            "stun:stun.cloudflare.com:3478",
+          ],
+        },
+      } as any)}
       storage={null}
     >
       <StatusMonitor />

--- a/apps/app/components/welcome/featured/Dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/Dreamshaper.tsx
@@ -79,7 +79,7 @@ export default function Dreamshaper() {
         eventData,
         "daydream",
         window.location.hostname,
-        user || undefined
+        user || undefined,
       );
     };
 
@@ -99,7 +99,7 @@ export default function Dreamshaper() {
           eventData,
           "daydream",
           window.location.hostname,
-          user || undefined
+          user || undefined,
         );
       }
 

--- a/apps/app/components/welcome/featured/Header.tsx
+++ b/apps/app/components/welcome/featured/Header.tsx
@@ -42,7 +42,7 @@ export const Header = () => {
                 location: "welcome_header",
               }}
               variant="outline"
-              className="alwaysAnimatedButton"
+              className="alwaysAnimatedButton rounded-md"
               size="sm"
             >
               Join Community
@@ -63,13 +63,21 @@ export const Header = () => {
         {!isMobile && !isFullscreen && (
           <>
             <div className="absolute bottom-3 left-0 flex items-center">
-              <Link
-                href="/"
-                className="flex items-center text-xs text-foreground hover:underline h-8"
+              <TrackedButton
+                trackingEvent="daydream_back_to_explore_clicked"
+                trackingProperties={{
+                  is_authenticated: authenticated,
+                }}
+                variant="ghost"
+                size="sm"
+                className="h-8 gap-2 rounded-md"
+                asChild
               >
-                <ChevronLeft className="h-3 w-3 mr-1" />
-                Back to explore
-              </Link>
+                <Link href="/">
+                  <ChevronLeft className="h-4 w-4" />
+                  <span>Back to explore</span>
+                </Link>
+              </TrackedButton>
             </div>
 
             <div
@@ -82,7 +90,7 @@ export const Header = () => {
                 {live && stream?.output_playback_id && streamUrl && (
                   <ClipButton
                     disabled={!stream?.output_playback_id || !streamUrl}
-                    className="mr-2"
+                    className="mr-2 rounded-md"
                     trackAnalytics={track}
                     isAuthenticated={authenticated}
                   />
@@ -94,7 +102,7 @@ export const Header = () => {
                   }}
                   variant="ghost"
                   size="sm"
-                  className="h-8 gap-2"
+                  className="h-8 gap-2 rounded-md"
                   onClick={openModal}
                 >
                   <Share className="h-4 w-4" />
@@ -119,6 +127,7 @@ export const Header = () => {
                 trackAnalytics={track}
                 isAuthenticated={authenticated}
                 isMobile={true}
+                className="rounded-md"
               />
             )}
 
@@ -126,7 +135,7 @@ export const Header = () => {
               <Button
                 variant="ghost"
                 size="icon"
-                className="p-0 m-0 bg-transparent border-none hover:bg-transparent focus:outline-none"
+                className="p-0 m-0 bg-transparent border-none hover:bg-transparent focus:outline-none rounded-md"
                 onClick={openModal}
               >
                 <Share2 className="h-4 w-4" />
@@ -137,7 +146,7 @@ export const Header = () => {
               <Button
                 variant="ghost"
                 size="icon"
-                className="p-0 m-0 bg-transparent border-none hover:bg-transparent focus:outline-none"
+                className="p-0 m-0 bg-transparent border-none hover:bg-transparent focus:outline-none rounded-md"
               >
                 <Users2 className="h-4 w-4" />
               </Button>
@@ -147,7 +156,7 @@ export const Header = () => {
               <Button
                 variant="ghost"
                 size="icon"
-                className="p-0 m-0 bg-transparent border-none hover:bg-transparent focus:outline-none"
+                className="p-0 m-0 bg-transparent border-none hover:bg-transparent focus:outline-none rounded-md"
               >
                 <Search className="h-4 w-4" />
               </Button>

--- a/apps/app/components/welcome/featured/InputPrompt.tsx
+++ b/apps/app/components/welcome/featured/InputPrompt.tsx
@@ -253,7 +253,7 @@ export const InputPrompt = () => {
   return (
     <div
       className={cn(
-        "relative mx-auto flex justify-center items-center gap-2 h-14 md:h-auto md:min-h-14 md:gap-2 mt-4 mb-2 dark:bg-[#1A1A1A] bg-white md:rounded-xl py-2.5 px-3 md:py-1.5 md:px-3 w-[calc(100%-2rem)] md:w-[calc(min(100%,800px))] border-2 border-muted-foreground/10",
+        "relative mx-auto flex justify-center items-center gap-2 h-14 md:h-auto md:min-h-14 md:gap-2 mt-4 mb-2 dark:bg-[#1A1A1A] bg-[#fefefe] md:rounded-xl py-2.5 px-3 md:py-1.5 md:px-3 w-[calc(100%-2rem)] md:w-[calc(min(100%,800px))] border-2 border-muted-foreground/10",
         isFullscreen
           ? isMobile
             ? "fixed left-1/2 bottom-[calc(env(safe-area-inset-bottom)+16px)] -translate-x-1/2 z-[10000] w-[600px] max-w-[calc(100%-2rem)] max-h-16 rounded-2xl"

--- a/apps/app/components/welcome/featured/Overlay.tsx
+++ b/apps/app/components/welcome/featured/Overlay.tsx
@@ -6,32 +6,28 @@ interface OverlayProps {
 
 export default function Overlay({ statusMessage }: OverlayProps) {
   return (
-    <div
-      className="absolute inset-0 flex flex-col items-center justify-center rounded-2xl z-[6]"
-      style={{
-        backgroundImage: "url('/background.png')",
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-        background:
-          "linear-gradient(118.41deg, #F1F1F1 7.25%, #83A5B5 54.22%, #E5ECEE 85.82%)",
-      }}
-    >
-      <Logo className="w-8 h-8 sm:w-10 sm:h-10 mb-6" />
-      <div className="flex flex-col items-center gap-6 justify-center max-w-80 text-foreground sm:mb-6">
-        <p className="shimmer-text shimmer-slow text-lg sm:text-xl font-semibold">
-          {statusMessage ? (
-            statusMessage
-          ) : (
-            <span>
-              Welcome to <span className="font-medium"> Daydream</span>
-            </span>
-          )}
-        </p>
-        <p className="text-foreground text-xs sm:text-sm text-center">
-          Thanks for dreaming with us — we&apos;re in beta, so <br /> you might
-          hit a few performance bumps
-        </p>
+    <>
+      <div className="absolute inset-0 rounded-2xl loading-gradient z-10"></div>
+      <div className="absolute inset-0 rounded-2xl backdrop-blur-[125px] z-20"></div>
+      <div className="absolute inset-0 flex flex-col items-center justify-center rounded-2xl z-20">
+        <Logo className="w-8 h-8 sm:w-10 sm:h-10 mb-6" />
+        <div className="flex flex-col items-center gap-6 justify-center max-w-80 text-foreground sm:mb-6">
+          <p className="shimmer-text shimmer-slow text-lg sm:text-xl font-semibold">
+            {statusMessage ? (
+              statusMessage
+            ) : (
+              <span>
+                Welcome to <span className="font-medium"> Daydream</span>
+              </span>
+            )}
+          </p>
+          <p className="text-foreground text-xs sm:text-sm text-center">
+            Thanks for dreaming with us — we&apos;re in beta, so <br /> you
+            might hit a few performance bumps
+          </p>
+        </div>
       </div>
-    </div>
+      <div className="pointer-events-none absolute inset-0 rounded-2xl shadow ring-1 ring-black/5 z-30"></div>
+    </>
   );
 }

--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -122,13 +122,15 @@ export const LivepeerPlayer = () => {
         backoffMax={1000}
         timeout={300000}
         lowLatency="force"
-        {...{iceServers: {
-          urls: [
-            "stun:stun.l.google.com:19302",
-            "stun:stun1.l.google.com:19302",
-            "stun:stun.cloudflare.com:3478",
-          ],
-        }} as any}
+        {...({
+          iceServers: {
+            urls: [
+              "stun:stun.l.google.com:19302",
+              "stun:stun1.l.google.com:19302",
+              "stun:stun.cloudflare.com:3478",
+            ],
+          },
+        } as any)}
         onError={handleError}
       >
         <div
@@ -139,7 +141,7 @@ export const LivepeerPlayer = () => {
         <Player.Video
           title="Live stream"
           data-testid="playback-video"
-          className="h-full w-full transition-all object-contain relative z-0 -scale-x-100"
+          className="h-full w-full transition-all object-contain relative z-0 -scale-x-100 bg-[#fefefe]"
         />
 
         <Player.LoadingIndicator className="w-full relative h-full bg-black/50 backdrop-blur data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0 z-[6]">
@@ -260,9 +262,7 @@ export const PlayerLoading = ({
   </div>
 );
 
-const useFirstFrameLoaded = ({
-  __scopeMedia,
-}: Player.MediaScopedProps) => {
+const useFirstFrameLoaded = ({ __scopeMedia }: Player.MediaScopedProps) => {
   const { user } = usePrivy();
   const { stream, pipeline } = useDreamshaperStore();
   const startTime = useRef(Date.now());
@@ -285,7 +285,7 @@ const useFirstFrameLoaded = ({
         },
         "daydream",
         "server",
-        user || undefined
+        user || undefined,
       );
     };
     sendEvent();
@@ -310,7 +310,7 @@ const useFirstFrameLoaded = ({
           },
           "daydream",
           "server",
-          user || undefined
+          user || undefined,
         );
       sendEvent();
     }

--- a/apps/app/components/welcome/featured/videojs-player.tsx
+++ b/apps/app/components/welcome/featured/videojs-player.tsx
@@ -228,7 +228,7 @@ const VideoJSPlayer: React.FC<VideoJSPlayerProps> = ({
         },
         "daydream",
         "server",
-        user || undefined
+        user || undefined,
       );
     };
     sendFirstFrameEvent();

--- a/apps/app/hooks/useFallbackDetection.ts
+++ b/apps/app/hooks/useFallbackDetection.ts
@@ -12,21 +12,24 @@ export const useFallbackDetection = (playbackId: string) => {
   const lastErrorTimeRef = useRef<number | null>(null);
   const errorIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const { user } = usePrivy();
-  
-  const trackFallbackEvent = useCallback((reason: string, errorDetails?: string) => {
-    sendKafkaEvent(
-      "stream_trace",
-      {
-        type: "app_player_fallback_to_videojs",
-        playback_id: playbackId,
-        reason: reason,
-        error_details: errorDetails || "",
-      },
-      "daydream",
-      "server",
-      user || undefined
-    );
-  }, [playbackId, user]);
+
+  const trackFallbackEvent = useCallback(
+    (reason: string, errorDetails?: string) => {
+      sendKafkaEvent(
+        "stream_trace",
+        {
+          type: "app_player_fallback_to_videojs",
+          playback_id: playbackId,
+          reason: reason,
+          error_details: errorDetails || "",
+        },
+        "daydream",
+        "server",
+        user || undefined,
+      );
+    },
+    [playbackId, user],
+  );
 
   const handleError = useCallback(
     (error: any) => {
@@ -74,7 +77,10 @@ export const useFallbackDetection = (playbackId: string) => {
           if (timeSinceLastError > TIME_TO_FALLBACK_VIDEOJS_MS && !isPlaying) {
             console.warn("Switching to VideoJS fallback player.");
             setUseFallbackPlayer(true);
-            trackFallbackEvent("timeout_error_reached", `Last error time: ${lastErrorTime}`);
+            trackFallbackEvent(
+              "timeout_error_reached",
+              `Last error time: ${lastErrorTime}`,
+            );
 
             if (errorIntervalRef.current) {
               clearInterval(errorIntervalRef.current);
@@ -103,5 +109,3 @@ export const useFallbackDetection = (playbackId: string) => {
 
   return { useFallbackPlayer, handleError, trackFallbackEvent };
 };
-
-

--- a/apps/app/lib/analytics/event-middleware.ts
+++ b/apps/app/lib/analytics/event-middleware.ts
@@ -24,7 +24,7 @@ export function standardizeEventData(
   data: any,
   app: string,
   host: string,
-  user?: User
+  user?: User,
 ): StandardizedEvent {
   const standardizedData: BaseEventData = {
     type: data.type,
@@ -51,14 +51,20 @@ export function sendBeaconEvent(
   data: any,
   app: string,
   host: string,
-  user?: User
+  user?: User,
 ): boolean {
   if (typeof navigator === "undefined" || !navigator.sendBeacon) {
     console.warn("Beacon API not supported");
     return false;
   }
 
-  const standardizedEvent = standardizeEventData(eventType, data, app, host, user);
+  const standardizedEvent = standardizeEventData(
+    eventType,
+    data,
+    app,
+    host,
+    user,
+  );
   const blob = new Blob([JSON.stringify(standardizedEvent)], {
     type: "application/json",
   });
@@ -74,10 +80,16 @@ export async function sendKafkaEvent(
   data: any,
   app: string,
   host: string,
-  user?: User
+  user?: User,
 ): Promise<string> {
-  const standardizedEvent = standardizeEventData(eventType, data, app, host, user);
-  
+  const standardizedEvent = standardizeEventData(
+    eventType,
+    data,
+    app,
+    host,
+    user,
+  );
+
   try {
     const response = await fetch("/api/metrics/log", {
       method: "POST",
@@ -96,4 +108,4 @@ export async function sendKafkaEvent(
     console.error("Error sending Kafka event:", error);
     return `Error sending event: ${error instanceof Error ? error.message : String(error)}`;
   }
-} 
+}

--- a/apps/app/lib/utils.ts
+++ b/apps/app/lib/utils.ts
@@ -5,10 +5,11 @@ export const sleep = (ms: number) =>
 
 export const isLivepeerEmail = (user: User | null | undefined): boolean => {
   if (!user) return false;
-  
-  const email = user.email?.address || user.google?.email || user.discord?.email;
+
+  const email =
+    user.email?.address || user.google?.email || user.discord?.email;
 
   if (!email) return false;
-  
+
   return email.endsWith("@livepeer.org");
 };


### PR DESCRIPTION
Now that we reverted player and broadcast related stuff, this PR:
- Re run pnpm format since some formatting was reverted
- Restore CSS-only changes on the loading player
- Make "back to explore" a button
- Add radius to header buttons
- Change the background of the video tag and the input prompt to fefefe  as designs
- Fix a situation where the prompt wasn't getting sent to the bento grid "Try this prompt" button