### PR TITLE
fix: autoplay videos threshold to 50%

### DIFF
--- a/apps/app/app/(main)/OptimizedVideo.tsx
+++ b/apps/app/app/(main)/OptimizedVideo.tsx
@@ -122,7 +122,7 @@ export default function OptimizedVideo({
           videoElement.pause();
         }
       },
-      { threshold: 0.9 },
+      { threshold: 0.5 },
     );
 
     playbackObserver.observe(containerRef.current);


### PR DESCRIPTION
- Due to threshold set to 90% it looked like the top fold videos were not autoplaying, by setting the threshold to 50%, we can now see that the videos are working as expected.


https://github.com/user-attachments/assets/97c0d5e8-7c5d-48b6-a30c-07fc0584ba50

