### PR TITLE
Fix version number padding

### DIFF
--- a/apps/app/components/footer/stream-info.tsx
+++ b/apps/app/components/footer/stream-info.tsx
@@ -16,7 +16,7 @@ export function StreamInfo({ className }: { className?: string }) {
 
   const handleCopy = async () => {
     const fullInfo = {
-      version: appVersion,
+      version: appVersion.toLowerCase(),
       browser: navigator.userAgent,
       path: window.location.pathname,
       streamId: stream?.id || "not-available",
@@ -35,7 +35,7 @@ export function StreamInfo({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "flex items-center gap-2 text-xs text-gray-500 z-10",
+        "fixed bottom-4 flex items-center gap-2 text-xs text-gray-500 z-10",
         isFullscreen && "hidden",
         className,
       )}

--- a/apps/app/components/footer/stream-info.tsx
+++ b/apps/app/components/footer/stream-info.tsx
@@ -35,7 +35,7 @@ export function StreamInfo({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "fixed bottom-4 right-4 flex items-center gap-2 text-xs text-gray-500 z-10",
+        "flex items-center gap-2 text-xs text-gray-500 z-10",
         isFullscreen && "hidden",
         className,
       )}

--- a/apps/app/components/footer/stream-info.tsx
+++ b/apps/app/components/footer/stream-info.tsx
@@ -35,7 +35,7 @@ export function StreamInfo({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "fixed bottom-4 right-20 flex items-center gap-2 text-xs text-gray-500 z-10",
+        "fixed bottom-4 right-4 flex items-center gap-2 text-xs text-gray-500 z-10",
         isFullscreen && "hidden",
         className,
       )}

--- a/apps/app/components/stream/stream-debug-panel.tsx
+++ b/apps/app/components/stream/stream-debug-panel.tsx
@@ -7,6 +7,7 @@ import useFullscreenStore from "@/hooks/useFullscreenStore";
 import { cn } from "@repo/design-system/lib/utils";
 import { usePrivy } from "@/hooks/usePrivy";
 import { isLivepeerEmail } from "@/lib/utils";
+import { StreamInfo } from "../footer/stream-info";
 
 interface ErrorHistoryItem {
   source: string;
@@ -99,6 +100,7 @@ export const StreamDebugPanel = () => {
             </button>
           </>
         )}
+        <StreamInfo />
       </div>
       {isAdmin && debugOpen && (
         <div

--- a/apps/app/components/welcome/featured/Dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/Dreamshaper.tsx
@@ -358,7 +358,6 @@ export default function Dreamshaper({ isGuestMode = false }: DreamshaperProps) {
             <InputPrompt onPromptSubmit={handleGuestPromptSubmit} />
           )}
           <StreamDebugPanel />
-          <StreamInfo />
         </div>
       </div>
 


### PR DESCRIPTION
This was driving me nuts - moved the version copy to center, so it's more easily accessible
