### PR TITLE
dd: fix: fix persistent guest store

### DIFF
--- a/apps/app/components/daydream/index.tsx
+++ b/apps/app/components/daydream/index.tsx
@@ -29,10 +29,17 @@ export default function Daydream({
   isOAuthSuccessRedirect,
   allowGuestAccess = false,
 }: DaydreamProps) {
-  const { user, ready } = usePrivy();
+  const { user, ready, authenticated } = usePrivy();
   const { isGuestUser, setIsGuestUser } = useGuestUserStore();
   const searchParams = useSearchParams();
   const inputPrompt = searchParams.get("inputPrompt");
+
+  // Always reset guest mode if user is authenticated
+  useEffect(() => {
+    if (authenticated && user && isGuestUser) {
+      setIsGuestUser(false);
+    }
+  }, [authenticated, user, isGuestUser, setIsGuestUser]);
 
   // If guest access is allowed and input prompt exists, enable guest mode
   useEffect(() => {


### PR DESCRIPTION
IsGuestMode was persisted in localStorage via Zustand's persist middleware, but there was no code that explicitly resetted this value when a user logs in - now this is fixed and fixing a edge case where logged in users would see the tutorial video or the sign up CTA modal after coming from a previous guest session

Note: very rare bug outside of development / internal sessions