### PR TITLE
e2e-test: Add dynamic selection of WHIP endpoint during E2E

### DIFF
--- a/apps/app-e2e/tests/common.ts
+++ b/apps/app-e2e/tests/common.ts
@@ -33,6 +33,15 @@ export const EXTENSION = "png";
 
 export const SEND_METRICS = process.env.SEND_METRICS === "true";
 
+export function selectWhipServer(path: string): string {
+  const REGIONS = (process.env.WHIP_REGIONS || "").split(",");
+  if (REGIONS.length > 0 && Math.random() > 0.49) {
+    const region = REGIONS[Math.floor(Math.random() * REGIONS.length)];
+    return `${path}?whipServer=https://${region}/live/video-to-video/`;
+  }
+  return path;
+}
+
 /**
  * Asserts that a video element is visible, loaded, playing, and progressing.
  * @param video - The Playwright Locator for the video element.

--- a/apps/app-e2e/tests/video.dev.spec.ts
+++ b/apps/app-e2e/tests/video.dev.spec.ts
@@ -2,6 +2,7 @@ import { test } from "@playwright/test";
 import {
   assertVideoContentChanging,
   assertVideoPlaying,
+  selectWhipServer,
   BROADCAST_VIDEO_TEST_ID,
   NUM_SCREENSHOTS,
   OVERALL_TEST_TIMEOUT_MS,
@@ -12,7 +13,7 @@ import {
 test.describe("Daydream Page Tests", () => {
   test.beforeEach(async ({ page, context }) => {
     await context.grantPermissions(["camera", "microphone"]);
-    await page.goto("/create");
+    await page.goto(selectWhipServer("/create"));
   });
 
   test("video elements load and play correctly", async ({ page }) => {

--- a/apps/app-e2e/tests/video.spec.ts
+++ b/apps/app-e2e/tests/video.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   assertVideoContentChanging,
   assertVideoPlaying,
+  selectWhipServer,
   BROADCAST_VIDEO_TEST_ID,
   MIN,
   NUM_SCREENSHOTS,
@@ -43,7 +44,7 @@ if (!APP_URL) {
 test.describe("Daydream Page Tests", () => {
   test.beforeEach(async ({ page, context }) => {
     await context.grantPermissions(["camera", "microphone"]);
-    await page.goto("/create");
+    await page.goto(selectWhipServer("/create"));
   });
 
   test.afterEach(async ({}, testInfo) => {


### PR DESCRIPTION
The selection is done if there exists a `WHIP_REGIONS` environment variable, which is a comma-separated list of endpoints.

There is also an additional 49% chance that whip selection will not happen and the E2E tests will continue with defaults.