### PR TITLE
fix: max prompt length reduced to prevent stream errors

### DIFF
--- a/apps/app/components/welcome/featured/useValidateInput.tsx
+++ b/apps/app/components/welcome/featured/useValidateInput.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { PROFANITY_WORD_LIST } from "./utils";
 
-export const MAX_PROMPT_LENGTH = 490;
+export const MAX_PROMPT_LENGTH = 300;
 
 export const useValidateInput = (prompt: string) => {
   const [profanity, setProfanity] = useState(false);


### PR DESCRIPTION
- Previously MAX_PROMPT_LENGTH was set to 490 chars, but we are seeing some errors now due to it causing stream failures. Reset it to 300 chars to allow the user to prevent sending it in the first place by adding client side validation.

Test Prompt From Bug Report:
```
Realistic women with black scary armor, Holding fire Sword,human face,long hair, perfectly detailed on dragon armors,Super detail face,high details on face,realistic face, character highly detailed, character sheets, Detailed, sharp focus, Super detailed full body, 32k resolution, Only a reality graphic,epic background,epic pose,horror,high resolution,Resonance,fire and ash background --quality 3)
```
