### PR TITLE
Upload clips + thumbnails via Presigned URLs. Remove size check. Increase max length to 60s.

### DIFF
--- a/apps/app/app/api/clips/presigned-thumbnail/route.ts
+++ b/apps/app/app/api/clips/presigned-thumbnail/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getPrivyUser } from "@/lib/auth";
-import { generatePresignedUploadUrl } from "@/lib/storage/gcp";
+import { generatePresignedUploadUrl, getPublicUrl } from "@/lib/storage/gcp";
 
 export async function POST(request: Request) {
   try {
@@ -32,6 +32,7 @@ export async function POST(request: Request) {
       success: true,
       uploadUrl,
       thumbnailPath,
+      publicUrl: getPublicUrl(thumbnailPath),
     });
   } catch (error) {
     console.error("Error generating thumbnail presigned URL:", error);

--- a/apps/app/app/api/clips/presigned-thumbnail/route.ts
+++ b/apps/app/app/api/clips/presigned-thumbnail/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { getPrivyUser } from "@/lib/auth";
+import { generatePresignedUploadUrl } from "@/lib/storage/gcp";
+
+export async function POST(request: Request) {
+  try {
+    const privyUser = await getPrivyUser();
+    if (!privyUser) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    
+    const userId = privyUser.userId;
+    const { clipId, contentType = "image/jpeg" } = await request.json();
+    
+    if (!clipId) {
+      return NextResponse.json(
+        { error: "Clip ID is required" },
+        { status: 400 }
+      );
+    }
+    
+    // Generate thumbnail path
+    const thumbnailPath = `clips/${userId}/${clipId}/thumbnail.jpg`;
+    
+    // Generate presigned URL for thumbnail
+    const uploadUrl = await generatePresignedUploadUrl(thumbnailPath, contentType);
+    
+    return NextResponse.json({
+      success: true,
+      uploadUrl,
+      thumbnailPath
+    });
+  } catch (error) {
+    console.error("Error generating thumbnail presigned URL:", error);
+    return NextResponse.json(
+      { error: "Failed to generate thumbnail upload URL" },
+      { status: 500 }
+    );
+  }
+} 

--- a/apps/app/app/api/clips/presigned-thumbnail/route.ts
+++ b/apps/app/app/api/clips/presigned-thumbnail/route.ts
@@ -8,33 +8,36 @@ export async function POST(request: Request) {
     if (!privyUser) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-    
+
     const userId = privyUser.userId;
     const { clipId, contentType = "image/jpeg" } = await request.json();
-    
+
     if (!clipId) {
       return NextResponse.json(
         { error: "Clip ID is required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
-    
+
     // Generate thumbnail path
     const thumbnailPath = `clips/${userId}/${clipId}/thumbnail.jpg`;
-    
+
     // Generate presigned URL for thumbnail
-    const uploadUrl = await generatePresignedUploadUrl(thumbnailPath, contentType);
-    
+    const uploadUrl = await generatePresignedUploadUrl(
+      thumbnailPath,
+      contentType,
+    );
+
     return NextResponse.json({
       success: true,
       uploadUrl,
-      thumbnailPath
+      thumbnailPath,
     });
   } catch (error) {
     console.error("Error generating thumbnail presigned URL:", error);
     return NextResponse.json(
       { error: "Failed to generate thumbnail upload URL" },
-      { status: 500 }
+      { status: 500 },
     );
   }
-} 
+}

--- a/apps/app/app/api/clips/presigned-upload/route.ts
+++ b/apps/app/app/api/clips/presigned-upload/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { getPrivyUser } from "@/lib/auth";
+import { buildClipPath } from "@/lib/storage/gcp";
+import { generatePresignedUploadUrl } from "@/lib/storage/gcp";
+import { customAlphabet } from "nanoid";
+
+// Generate a random ID for the clip
+const generateId = customAlphabet("1234567890", 10);
+
+export async function POST(request: Request) {
+  try {
+    const privyUser = await getPrivyUser();
+    if (!privyUser) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    
+    const userId = privyUser.userId;
+    const { contentType, filename } = await request.json();
+    
+    if (!contentType) {
+      return NextResponse.json(
+        { error: "Content-Type is required" },
+        { status: 400 }
+      );
+    }
+    
+    // Generate clip ID
+    const clipId = generateId();
+    
+    // Generate the file path in GCS
+    const filePath = buildClipPath(userId, clipId, filename || "clip.mp4");
+    
+    // Generate presigned URL
+    const uploadUrl = await generatePresignedUploadUrl(filePath, contentType);
+    
+    // Generate thumbnail path if needed (for later reference)
+    const thumbnailPath = `clips/${userId}/${clipId}/thumbnail.jpg`;
+    
+    return NextResponse.json({
+      success: true,
+      uploadUrl,
+      clipId,
+      filePath,
+      thumbnailPath
+    });
+  } catch (error) {
+    console.error("Error generating presigned URL:", error);
+    return NextResponse.json(
+      { error: "Failed to generate upload URL" },
+      { status: 500 }
+    );
+  }
+} 

--- a/apps/app/app/api/clips/presigned-upload/route.ts
+++ b/apps/app/app/api/clips/presigned-upload/route.ts
@@ -13,41 +13,41 @@ export async function POST(request: Request) {
     if (!privyUser) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-    
+
     const userId = privyUser.userId;
     const { contentType, filename } = await request.json();
-    
+
     if (!contentType) {
       return NextResponse.json(
         { error: "Content-Type is required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
-    
+
     // Generate clip ID
     const clipId = generateId();
-    
+
     // Generate the file path in GCS
     const filePath = buildClipPath(userId, clipId, filename || "clip.mp4");
-    
+
     // Generate presigned URL
     const uploadUrl = await generatePresignedUploadUrl(filePath, contentType);
-    
+
     // Generate thumbnail path if needed (for later reference)
     const thumbnailPath = `clips/${userId}/${clipId}/thumbnail.jpg`;
-    
+
     return NextResponse.json({
       success: true,
       uploadUrl,
       clipId,
       filePath,
-      thumbnailPath
+      thumbnailPath,
     });
   } catch (error) {
     console.error("Error generating presigned URL:", error);
     return NextResponse.json(
       { error: "Failed to generate upload URL" },
-      { status: 500 }
+      { status: 500 },
     );
   }
-} 
+}

--- a/apps/app/app/api/clips/presigned-upload/route.ts
+++ b/apps/app/app/api/clips/presigned-upload/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getPrivyUser } from "@/lib/auth";
-import { buildClipPath } from "@/lib/storage/gcp";
+import { buildClipPath, getPublicUrl } from "@/lib/storage/gcp";
 import { generatePresignedUploadUrl } from "@/lib/storage/gcp";
 import { customAlphabet } from "nanoid";
 
@@ -42,6 +42,7 @@ export async function POST(request: Request) {
       clipId,
       filePath,
       thumbnailPath,
+      publicUrl: getPublicUrl(filePath),
     });
   } catch (error) {
     console.error("Error generating presigned URL:", error);

--- a/apps/app/app/api/clips/route.ts
+++ b/apps/app/app/api/clips/route.ts
@@ -239,7 +239,7 @@ export async function POST(request: NextRequest) {
           { status: 400 },
         );
       }
-      
+
       // Make sure we use the full URL with correct bucket name
       let finalVideoUrl = videoUrl;
       if (filePath) {
@@ -249,12 +249,15 @@ export async function POST(request: NextRequest) {
         // If videoUrl doesn't contain the domain, treat it as a path
         finalVideoUrl = getPublicUrl(videoUrl);
       }
-      
+
       // Same for thumbnail
       let finalThumbnailUrl = thumbnailUrl;
       if (thumbnailPath) {
         finalThumbnailUrl = getPublicUrl(thumbnailPath);
-      } else if (thumbnailUrl && !thumbnailUrl.includes("storage.googleapis.com")) {
+      } else if (
+        thumbnailUrl &&
+        !thumbnailUrl.includes("storage.googleapis.com")
+      ) {
         finalThumbnailUrl = getPublicUrl(thumbnailUrl);
       }
 

--- a/apps/app/app/api/clips/route.ts
+++ b/apps/app/app/api/clips/route.ts
@@ -207,28 +207,34 @@ export async function POST(request: NextRequest) {
     userId = privyUser.userId;
 
     const contentType = request.headers.get("content-type") || "";
-    
+
     if (contentType.includes("application/json")) {
       const jsonData = await request.json();
-      
+
       const result = ClipUploadSchema.safeParse(jsonData);
-      
+
       if (!result.success) {
         return NextResponse.json(
           { error: "Invalid request", details: result.error.format() },
-          { status: 400 }
+          { status: 400 },
         );
       }
-      
-      const { clipId: externalClipId, videoUrl, thumbnailUrl, prompt, isFeatured } = jsonData;
-      
+
+      const {
+        clipId: externalClipId,
+        videoUrl,
+        thumbnailUrl,
+        prompt,
+        isFeatured,
+      } = jsonData;
+
       if (!externalClipId || !videoUrl) {
         return NextResponse.json(
           { error: "Missing required fields: clipId and videoUrl" },
-          { status: 400 }
+          { status: 400 },
         );
       }
-      
+
       const { initialClipId, slug } = await db.transaction(async tx => {
         const [newClip] = await tx
           .insert(clipsTable)

--- a/apps/app/components/daydream/Clipping/ClipSummaryContent.tsx
+++ b/apps/app/components/daydream/Clipping/ClipSummaryContent.tsx
@@ -74,10 +74,10 @@ export function ClipSummaryContent({
 
         // Upload the clip directly to Google Cloud Storage
         await uploadWithPresignedUrl(presignedData.uploadUrl, blob);
-        
+
         // Get the public URL of the uploaded clip (use the one provided by the API)
         const gcsPublicUrl = presignedData.publicUrl;
-        
+
         // Upload thumbnail if available
         let thumbnailUrl = null;
         let thumbnailPath = null;
@@ -85,7 +85,7 @@ export function ClipSummaryContent({
           try {
             const thumbnailResponse = await fetch(clipData.thumbnailUrl);
             const thumbnailBlob = await thumbnailResponse.blob();
-            
+
             // Get a presigned URL for uploading the thumbnail
             const thumbnailPresignedResponse = await fetch(
               "/api/clips/presigned-thumbnail",
@@ -100,17 +100,17 @@ export function ClipSummaryContent({
                 }),
               },
             );
-            
+
             if (thumbnailPresignedResponse.ok) {
               const thumbnailPresignedData =
                 await thumbnailPresignedResponse.json();
-              
+
               // Upload the thumbnail directly to Google Cloud Storage
               await uploadWithPresignedUrl(
                 thumbnailPresignedData.uploadUrl,
                 thumbnailBlob,
               );
-              
+
               // Get the public URL of the uploaded thumbnail (use the one provided by the API)
               thumbnailUrl = thumbnailPresignedData.publicUrl;
               thumbnailPath = thumbnailPresignedData.thumbnailPath;

--- a/apps/app/hooks/useVideoClip.ts
+++ b/apps/app/hooks/useVideoClip.ts
@@ -12,8 +12,7 @@ declare global {
 
 export type ClipRecordingMode = "horizontal" | "vertical" | "output-only";
 
-export const CLIP_DURATION = 30000;
-const MAX_CLIP_SIZE = 4 * 1024 * 1024; // 4MB in bytes
+export const CLIP_DURATION = 60000;
 
 const FRAME_RATE = 30;
 const INPUT_DELAY = 1000; // 1 second delay for input video - increase or decreas to sync
@@ -200,20 +199,9 @@ export const useVideoClip = () => {
     const mediaRecorder = new MediaRecorder(canvasStream, { mimeType });
 
     const chunks: Blob[] = [];
-    let totalSize = 0;
     mediaRecorder.ondataavailable = e => {
       if (e.data.size > 0) {
         chunks.push(e.data);
-        totalSize += e.data.size;
-
-        // Stop recording if we've reached the size limit
-        if (totalSize >= MAX_CLIP_SIZE) {
-          mediaRecorder.stop();
-          clearInterval(progressInterval);
-          if (timeoutId) clearTimeout(timeoutId);
-          isDrawing = false;
-          if (animationFrameId) cancelAnimationFrame(animationFrameId);
-        }
       }
     };
 

--- a/apps/app/lib/storage/gcp.ts
+++ b/apps/app/lib/storage/gcp.ts
@@ -1,4 +1,4 @@
-import { Storage } from "@google-cloud/storage";
+import { Storage, GetSignedUrlConfig } from "@google-cloud/storage";
 import { gcpConfig } from "../serverEnv";
 
 let storage: Storage;
@@ -52,6 +52,30 @@ export async function uploadToGCS(
   } catch (error) {
     console.error("Error uploading to GCS:", error);
     throw new Error("Failed to upload file to Google Cloud Storage");
+  }
+}
+
+export async function generatePresignedUploadUrl(
+  path: string,
+  contentType: string,
+  expiresInMinutes: number = 15
+): Promise<string> {
+  const bucket = storage.bucket(bucketName);
+  const file = bucket.file(path);
+  
+  const options: GetSignedUrlConfig = {
+    version: 'v4' as 'v4',
+    action: 'write' as 'write',
+    expires: Date.now() + expiresInMinutes * 60 * 1000,
+    contentType
+  };
+
+  try {
+    const [signedUrl] = await file.getSignedUrl(options);
+    return signedUrl;
+  } catch (error) {
+    console.error("Error generating presigned URL:", error);
+    throw new Error("Failed to generate presigned upload URL");
   }
 }
 

--- a/apps/app/lib/storage/gcp.ts
+++ b/apps/app/lib/storage/gcp.ts
@@ -58,16 +58,16 @@ export async function uploadToGCS(
 export async function generatePresignedUploadUrl(
   path: string,
   contentType: string,
-  expiresInMinutes: number = 15
+  expiresInMinutes: number = 15,
 ): Promise<string> {
   const bucket = storage.bucket(bucketName);
   const file = bucket.file(path);
-  
+
   const options: GetSignedUrlConfig = {
-    version: 'v4' as 'v4',
-    action: 'write' as 'write',
+    version: "v4" as "v4",
+    action: "write" as "write",
     expires: Date.now() + expiresInMinutes * 60 * 1000,
-    contentType
+    contentType,
   };
 
   try {

--- a/apps/app/lib/storage/gcp.ts
+++ b/apps/app/lib/storage/gcp.ts
@@ -17,6 +17,10 @@ try {
 
 const bucketName = gcpConfig.bucketName || "daydream-clips";
 
+export function getPublicUrl(path: string): string {
+  return `https://storage.googleapis.com/${bucketName}/${path}`;
+}
+
 export async function uploadToGCS(
   file: Buffer | NodeJS.ReadableStream,
   path: string,


### PR DESCRIPTION
We were previously hitting a Vercel API limit where request > 4.5Mb gets rejected.

The API now returns a presigned GCP URL and the frontend uploads directly there.