### PR TITLE
fix: mismatch between selected avatar and displayed one

### DIFF
--- a/apps/app/app/(main)/BentoGrids.tsx
+++ b/apps/app/app/(main)/BentoGrids.tsx
@@ -184,6 +184,7 @@ export function BentoGrids({
                     slug={clip.slug}
                     title={clip.video_title || "Vincent Van Gogh"}
                     authorName={clip.author_name || "Livepeer"}
+                    authorDetails={clip.author_details as Record<string, any>}
                     src={clip.video_url}
                     prompt={clip.prompt}
                     createdAt={clip.created_at}
@@ -226,6 +227,7 @@ function GridItem({
   slug,
   title,
   authorName,
+  authorDetails,
   createdAt,
   remixCount,
   isDebug,
@@ -245,6 +247,7 @@ function GridItem({
   isDebug: boolean;
   overallIndex: number;
   isOverlayMode?: boolean;
+  authorDetails?: Record<string, any>;
   onTryPrompt?: (prompt: string) => void;
 }) {
   const href = slug ? `/clip/${slug}` : `/clip/id/${clipId}`;
@@ -294,6 +297,7 @@ function GridItem({
           title={title}
           slug={slug}
           authorName={authorName}
+          authorDetails={authorDetails}
           createdAt={createdAt}
           remixCount={remixCount}
           isOverlayMode={isOverlayMode}

--- a/apps/app/app/(main)/OptimizedVideo.tsx
+++ b/apps/app/app/(main)/OptimizedVideo.tsx
@@ -25,6 +25,7 @@ interface OptimizedVideoProps {
   title: string;
   slug: string | null;
   authorName: string;
+  authorDetails?: Record<string, any>;
   createdAt: string;
   remixCount: number;
   className?: string;
@@ -39,6 +40,7 @@ export default function OptimizedVideo({
   title,
   slug,
   authorName,
+  authorDetails,
   createdAt,
   remixCount,
   className,
@@ -166,7 +168,11 @@ export default function OptimizedVideo({
               )}
             />
             <div className="absolute bottom-3 left-3 p-0 z-10 flex gap-2 items-center">
-              <GradientAvatar seed={authorName} size={24} className="h-6 w-6" />
+              <GradientAvatar
+                seed={authorDetails?.avatar ?? authorName}
+                size={24}
+                className="h-6 w-6"
+              />
               <span className="text-white text-[0.64rem] bg-black/20 backdrop-blur-sm px-2 py-1 rounded-lg">
                 {authorName}
               </span>

--- a/apps/app/app/(main)/QuickviewVideo.tsx
+++ b/apps/app/app/(main)/QuickviewVideo.tsx
@@ -37,7 +37,6 @@ interface QuickviewVideoProps {
   createdAt: string;
   authorName: string;
   authorDetails?: Record<string, any>;
-  remixCount: number;
 }
 
 export default function QuickviewVideo({
@@ -49,7 +48,6 @@ export default function QuickviewVideo({
   authorName,
   authorDetails,
   createdAt,
-  remixCount,
 }: QuickviewVideoProps) {
   const { setIsPreviewOpen, isPreviewOpen } = usePreviewStore();
   const router = useRouter();

--- a/apps/app/app/(main)/QuickviewVideo.tsx
+++ b/apps/app/app/(main)/QuickviewVideo.tsx
@@ -36,6 +36,7 @@ interface QuickviewVideoProps {
   title: string;
   createdAt: string;
   authorName: string;
+  authorDetails?: Record<string, any>;
   remixCount: number;
 }
 
@@ -46,6 +47,7 @@ export default function QuickviewVideo({
   prompt,
   title,
   authorName,
+  authorDetails,
   createdAt,
   remixCount,
 }: QuickviewVideoProps) {
@@ -114,7 +116,7 @@ export default function QuickviewVideo({
                 <div className="flex items-center gap-2">
                   <div className="w-6 h-6 rounded-full bg-zinc-100 flex items-center justify-center">
                     <GradientAvatar
-                      seed={authorName}
+                      seed={authorDetails?.avatar ?? authorName}
                       size={24}
                       className="h-6 w-6"
                     />

--- a/apps/app/app/(main)/clips/[slug]/page.tsx
+++ b/apps/app/app/(main)/clips/[slug]/page.tsx
@@ -16,11 +16,7 @@ async function getClipBySlug(slug: string) {
       video_title: clipsTable.video_title,
       created_at: clipsTable.created_at,
       prompt: clipsTable.prompt,
-      remix_count: sql<number>`(
-          SELECT count(*)
-          FROM ${clipsTable} AS remixed_clips
-          WHERE remixed_clips.source_clip_id = ${clipsTable.id}
-        )`.mapWith(Number),
+      remix_count: clipsTable.remix_count,
       author_name: usersTable.name,
       author_details: usersTable.additionalDetails,
       slug: clipSlugsTable.slug,
@@ -53,7 +49,6 @@ export default async function Page({ params }: { params: { slug: string } }) {
         authorName={clip.author_name || "Livepeer"}
         authorDetails={clip.author_details as any}
         createdAt={clip.created_at.toISOString()}
-        remixCount={clip.remix_count}
       >
         <></>
       </QuickviewVideo>

--- a/apps/app/app/(main)/clips/[slug]/page.tsx
+++ b/apps/app/app/(main)/clips/[slug]/page.tsx
@@ -22,6 +22,7 @@ async function getClipBySlug(slug: string) {
           WHERE remixed_clips.source_clip_id = ${clipsTable.id}
         )`.mapWith(Number),
       author_name: usersTable.name,
+      author_details: usersTable.additionalDetails,
       slug: clipSlugsTable.slug,
     })
     .from(clipsTable)
@@ -50,6 +51,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
         prompt={clip.prompt}
         title={clip.video_title || "Vincent Van Gogh"}
         authorName={clip.author_name || "Livepeer"}
+        authorDetails={clip.author_details as any}
         createdAt={clip.created_at.toISOString()}
         remixCount={clip.remix_count}
       >

--- a/apps/app/app/(main)/hooks/useClipsFetcher.ts
+++ b/apps/app/app/(main)/hooks/useClipsFetcher.ts
@@ -7,6 +7,7 @@ export type Clip = {
   created_at: string;
   prompt?: string;
   author_name: string | null;
+  author_details?: Record<string, any>;
   remix_count: number;
   slug: string | null;
   priority: number | null;
@@ -38,6 +39,7 @@ export default function useClipsFetcher(initialClips: Clip[] = []) {
             created_at?: string | Date;
             prompt?: string;
             author_name?: string | null;
+            author_details?: Record<string, any>;
             remix_count: number;
             slug: string | null;
             [key: string]: any;
@@ -51,6 +53,7 @@ export default function useClipsFetcher(initialClips: Clip[] = []) {
             video_url: clip.video_url,
             prompt: clip.prompt || "",
             author_name: clip.author_name || null,
+            author_details: clip.author_details,
             remix_count: clip.remix_count,
             slug: clip.slug,
           }),

--- a/apps/app/app/(main)/layout.tsx
+++ b/apps/app/app/(main)/layout.tsx
@@ -18,6 +18,7 @@ type InitialFetchedClip = {
   prompt: string;
   remix_count: number;
   author_name: string | null;
+  author_details: Record<string, any> | null;
   slug: string | null;
   priority: number | null;
 };
@@ -31,6 +32,7 @@ async function getInitialClips() {
     prompt: clipsTable.prompt,
     remix_count: clipsTable.remix_count,
     author_name: usersTable.name,
+    author_details: usersTable.additionalDetails,
     slug: clipSlugsTable.slug,
     priority: clipsTable.priority,
   };
@@ -139,6 +141,7 @@ async function getInitialClips() {
     created_at: clip.created_at.toISOString(),
     prompt: clip.prompt,
     author_name: clip.author_name,
+    author_details: clip.author_details,
     remix_count: clip.remix_count,
     slug: clip.slug,
     priority: clip.priority,

--- a/apps/app/app/api/clips/[id]/route.ts
+++ b/apps/app/app/api/clips/[id]/route.ts
@@ -26,6 +26,7 @@ export async function GET(
         thumbnail_url: clipsTable.thumbnail_url,
         author_user_id: clipsTable.author_user_id,
         author_name: usersTable.name,
+        author_details: usersTable.additionalDetails,
         created_at: clipsTable.created_at,
         prompt: clipsTable.prompt,
       })
@@ -64,6 +65,7 @@ export async function GET(
       thumbnailUrl: clip.thumbnail_url,
       authorId: clip.author_user_id,
       authorName: clip.author_name,
+      authorDetails: clip.author_details,
       createdAt: clip.created_at,
       prompt: clip.prompt,
     });

--- a/apps/app/components/welcome/featured/BentoGridOverlay.tsx
+++ b/apps/app/components/welcome/featured/BentoGridOverlay.tsx
@@ -286,6 +286,7 @@ export const BentoGridOverlay = () => {
                   prompt: selectedClip.prompt,
                   title: selectedClip.title || "",
                   authorName: selectedClip.authorName || "Livepeer",
+                  authorDetails: selectedClip.authorDetails,
                   createdAt: selectedClip.createdAt,
                 }}
                 onTryPrompt={handleTryPrompt}

--- a/apps/app/components/welcome/featured/OverlayClipViewer.tsx
+++ b/apps/app/components/welcome/featured/OverlayClipViewer.tsx
@@ -14,6 +14,7 @@ interface OverlayClipViewerProps {
     prompt?: string;
     title?: string;
     authorName?: string;
+    authorDetails?: Record<string, any>;
     createdAt: string;
   };
   onTryPrompt: (prompt: string) => void;
@@ -42,7 +43,10 @@ export const OverlayClipViewer = ({
             <div className="flex items-center gap-2">
               <div className="w-6 h-6 rounded-full bg-zinc-100 flex items-center justify-center">
                 <GradientAvatar
-                  seed={clip.authorName || "Anonymous"}
+                  seed={
+                    clip.authorDetails?.avatar ??
+                    (clip.authorName || "Anonymous")
+                  }
                   size={24}
                   className="h-6 w-6"
                 />


### PR DESCRIPTION
- Avatar selected on registration != Explore page one
- This PR fixes the references of avatar seed used to generate the Gradient to pick it up from the DB instead of userName.

## Tested on:
- Quickview Video
- Explore page
- Overlay Section