### PR TITLE
fix: create CTA in NoMoreClipsFooter Button

### DIFF
--- a/apps/app/app/(main)/BentoGrids.tsx
+++ b/apps/app/app/(main)/BentoGrids.tsx
@@ -209,7 +209,7 @@ export function BentoGrids({
           ) : hasMore && (!isOverlayMode || initialClips.length === 0) ? (
             <p className="text-gray-500 font-light">Scroll for more</p>
           ) : (
-            <NoMoreClipsFooter />
+            <NoMoreClipsFooter isOverlayMode={isOverlayMode} />
           )}
           <div
             aria-hidden="true"

--- a/apps/app/app/(main)/NoMoreClipsFooter.tsx
+++ b/apps/app/app/(main)/NoMoreClipsFooter.tsx
@@ -1,12 +1,27 @@
 "use client";
 
 import Link from "next/link";
-import { cn } from "@repo/design-system/lib/utils";
 import { Button } from "@repo/design-system/components/ui/button";
 import { usePrivy } from "@/hooks/usePrivy";
+import { useOverlayStore } from "@/hooks/useOverlayStore";
+import { useRouter } from "next/navigation";
 
-export default function NoMoreClipsFooter() {
+export default function NoMoreClipsFooter({
+  isOverlayMode = false,
+}: {
+  isOverlayMode?: boolean;
+}) {
   const { authenticated } = usePrivy();
+  const { closeOverlay } = useOverlayStore();
+  const router = useRouter();
+
+  const handleCTAClick = () => {
+    if (isOverlayMode) {
+      closeOverlay();
+    } else {
+      router.push("/create");
+    }
+  };
 
   return (
     <div className="relative w-full mt-[-12rem]">
@@ -41,22 +56,25 @@ export default function NoMoreClipsFooter() {
           Your adventure awaits
         </h2>
 
-        <Link href="/create" className="relative z-10 mt-12">
-          <Button
-            variant="outline"
-            className="alwaysAnimatedButton"
-            style={{
-              paddingTop: "20px",
-              paddingRight: "53px",
-              paddingBottom: "20px",
-              paddingLeft: "53px",
-              gap: "4px",
-              borderRadius: "8px",
-            }}
-          >
-            {authenticated ? "Create" : "Sign Up"}
-          </Button>
-        </Link>
+        <Button
+          variant="outline"
+          className="z-10 mt-12 alwaysAnimatedButton"
+          style={{
+            paddingTop: "20px",
+            paddingRight: "53px",
+            paddingBottom: "20px",
+            paddingLeft: "53px",
+            gap: "4px",
+            borderRadius: "8px",
+          }}
+          onClick={handleCTAClick}
+        >
+          {authenticated
+            ? isOverlayMode
+              ? "Continue Creating"
+              : "Create"
+            : "Sign Up"}
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
- On the Overlay Mode we see that the Create CTA is pointing towards the /create page on which the user is already present. Hence we see a no-op in this case. 
- Updated the functionality to close the overlay in such cases and changes the copy to "Continue Creating" instead of "Create" in overlay mode.

https://github.com/user-attachments/assets/c346e6a9-c8f4-4c7f-b56f-743227240f8f

