### PR TITLE
feat: add is_tutorial support for clips

### DIFF
--- a/apps/app/app/(main)/BentoGrids.tsx
+++ b/apps/app/app/(main)/BentoGrids.tsx
@@ -190,6 +190,7 @@ export function BentoGrids({
                     prompt={clip.prompt}
                     createdAt={clip.created_at}
                     remixCount={clip.remix_count}
+                    isTutorial={clip.is_tutorial}
                     className={`${index % 2 === 0 ? "lg:row-span-2" : ""} cursor-pointer`}
                     isDebug={isDebug}
                     overallIndex={overallIndex}
@@ -237,6 +238,7 @@ function GridItem({
   isOverlayMode = false,
   onTryPrompt,
   hasCapacity,
+  isTutorial,
 }: {
   clipId: string;
   src: string;
@@ -253,6 +255,7 @@ function GridItem({
   authorDetails?: Record<string, any>;
   onTryPrompt?: (prompt: string) => void;
   hasCapacity?: boolean;
+  isTutorial?: boolean;
 }) {
   const href = slug ? `/clip/${slug}` : `/clip/id/${clipId}`;
   const { isPreviewOpen } = usePreviewStore();
@@ -298,6 +301,7 @@ function GridItem({
           isOverlayMode={isOverlayMode}
           onTryPrompt={onTryPrompt}
           hasCapacity={hasCapacity}
+          isTutorial={isTutorial}
         />
       </div>
 

--- a/apps/app/app/(main)/BentoGrids.tsx
+++ b/apps/app/app/(main)/BentoGrids.tsx
@@ -31,6 +31,7 @@ export interface BentoGridsProps {
     remix_count: number;
     slug: string | null;
     priority: number | null;
+    is_tutorial?: boolean;
   }>;
   isOverlayMode?: boolean;
   onTryPrompt?: (prompt: string) => void;

--- a/apps/app/app/(main)/OptimizedVideo.tsx
+++ b/apps/app/app/(main)/OptimizedVideo.tsx
@@ -2,7 +2,7 @@ import { GradientAvatar } from "@/components/GradientAvatar";
 import { usePreviewStore } from "@/hooks/usePreviewStore";
 import { useOverlayStore } from "@/hooks/useOverlayStore";
 import { cn } from "@repo/design-system/lib/utils";
-import { Repeat } from "lucide-react";
+import { PlayCircle, Repeat } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { TrackedButton } from "@/components/analytics/TrackedButton";
 import { TrackedLink } from "@/components/analytics/TrackedLink";
@@ -34,6 +34,7 @@ interface OptimizedVideoProps {
   isOverlayMode?: boolean;
   onTryPrompt?: (prompt: string) => void;
   hasCapacity?: boolean;
+  isTutorial?: boolean;
 }
 
 export default function OptimizedVideo({
@@ -50,6 +51,7 @@ export default function OptimizedVideo({
   isOverlayMode = false,
   onTryPrompt,
   hasCapacity = true,
+  isTutorial = false,
 }: OptimizedVideoProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [isNearViewport, setIsNearViewport] = useState(false);
@@ -230,7 +232,24 @@ export default function OptimizedVideo({
               onClick={e => e.stopPropagation()}
             >
               <div onClick={e => e.stopPropagation()}>
-                {isOverlayMode && onTryPrompt && prompt ? (
+                {isTutorial ? (
+                  <TrackedButton
+                    trackingEvent="tutorial_video_clicked"
+                    trackingProperties={{ location: "video_card" }}
+                    variant="outline"
+                    className="inline-flex items-center space-x-0.5 px-3 py-2 h-8 bg-black/20 backdrop-blur-md text-white rounded-full border-white border shadow-sm scale-90"
+                    onClick={e => {
+                      e.stopPropagation();
+                      router.push(`/clips/${slug || clipId}`);
+                    }}
+                  >
+                    {/* Our default button overrides the size of child SVGs. Rather than change the button, I've overridden the CSS here. */}
+                    <PlayCircle className={cn("!w-3 !h-3")} />
+                    <span className="text-[0.7rem] tracking-wide">
+                      Tutorial
+                    </span>
+                  </TrackedButton>
+                ) : isOverlayMode && onTryPrompt && prompt ? (
                   <TrackedButton
                     trackingEvent="overlay_try_prompt_clicked"
                     trackingProperties={{ location: "overlay_video_card" }}

--- a/apps/app/app/(main)/QuickviewVideo.tsx
+++ b/apps/app/app/(main)/QuickviewVideo.tsx
@@ -22,6 +22,7 @@ import { VideoProvider } from "./VideoProvider";
 import { useCapacityCheck } from "@/hooks/useCapacityCheck";
 import { CapacityNotificationModal } from "@/components/modals/capacity-notification-modal";
 import track from "@/lib/track";
+import { toast } from "sonner";
 
 const formatter = new Intl.DateTimeFormat("en-US", {
   month: "short",
@@ -40,6 +41,7 @@ interface QuickviewVideoProps {
   createdAt: string;
   authorName: string;
   authorDetails?: Record<string, any>;
+  isTutorial?: boolean;
 }
 
 export default function QuickviewVideo({
@@ -51,6 +53,7 @@ export default function QuickviewVideo({
   authorName,
   authorDetails,
   createdAt,
+  isTutorial,
 }: QuickviewVideoProps) {
   const { setIsPreviewOpen, isPreviewOpen } = usePreviewStore();
   const router = useRouter();
@@ -153,15 +156,17 @@ export default function QuickviewVideo({
                   </div>
                 </div>
 
-                <Link
-                  href="#"
-                  onClick={handleTryPrompt}
-                  className={cn(
-                    "alwaysAnimatedButton text-xs py-2 px-8 h-auto",
-                  )}
-                >
-                  Try this prompt
-                </Link>
+                {!isTutorial && (
+                  <Link
+                    href="#"
+                    onClick={handleTryPrompt}
+                    className={cn(
+                      "alwaysAnimatedButton text-xs py-2 px-8 h-auto",
+                    )}
+                  >
+                    Try this prompt
+                  </Link>
+                )}
               </div>
             </DialogHeader>
 
@@ -173,7 +178,13 @@ export default function QuickviewVideo({
               </VideoProvider>
             </div>
 
-            <DialogFooter className="mt-6">
+            <DialogFooter
+              className="mt-6 hover:cursor-pointer"
+              onClick={() => {
+                navigator.clipboard.writeText(prompt || "");
+                toast.success("Prompt copied to clipboard");
+              }}
+            >
               <div className="w-[70%] mt-6 mx-auto">
                 <p className="text-xs font-normal text-[#707070] text-center line-clamp-2">
                   {prompt || "No prompt available"}

--- a/apps/app/app/(main)/clips/[slug]/page.tsx
+++ b/apps/app/app/(main)/clips/[slug]/page.tsx
@@ -23,6 +23,7 @@ const getClipBySlug = cache(async (slug: string) => {
       author_name: usersTable.name,
       author_details: usersTable.additionalDetails,
       slug: clipSlugsTable.slug,
+      is_tutorial: clipsTable.is_tutorial,
     })
     .from(clipsTable)
     .innerJoin(usersTable, eq(clipsTable.author_user_id, usersTable.id))
@@ -139,6 +140,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
         authorName={clip.author_name || "Livepeer"}
         authorDetails={clip.author_details as any}
         createdAt={clip.created_at.toISOString()}
+        isTutorial={clip.is_tutorial || false}
       >
         <></>
       </QuickviewVideo>

--- a/apps/app/app/(main)/hooks/useClipsFetcher.ts
+++ b/apps/app/app/(main)/hooks/useClipsFetcher.ts
@@ -11,6 +11,7 @@ export type Clip = {
   remix_count: number;
   slug: string | null;
   priority: number | null;
+  is_tutorial?: boolean;
 };
 
 export default function useClipsFetcher(initialClips: Clip[] = []) {
@@ -42,6 +43,7 @@ export default function useClipsFetcher(initialClips: Clip[] = []) {
             author_details?: Record<string, any>;
             remix_count: number;
             slug: string | null;
+            is_tutorial?: boolean;
             [key: string]: any;
           }) => ({
             ...clip,
@@ -56,6 +58,7 @@ export default function useClipsFetcher(initialClips: Clip[] = []) {
             author_details: clip.author_details,
             remix_count: clip.remix_count,
             slug: clip.slug,
+            is_tutorial: clip.is_tutorial || false,
           }),
         );
 

--- a/apps/app/app/(main)/layout.tsx
+++ b/apps/app/app/(main)/layout.tsx
@@ -21,6 +21,7 @@ type InitialFetchedClip = {
   author_details: Record<string, any> | null;
   slug: string | null;
   priority: number | null;
+  is_tutorial: boolean;
 };
 
 async function getInitialClips() {
@@ -35,6 +36,7 @@ async function getInitialClips() {
     author_details: usersTable.additionalDetails,
     slug: clipSlugsTable.slug,
     priority: clipsTable.priority,
+    is_tutorial: clipsTable.is_tutorial,
   };
 
   const prioritizedClips = (await db
@@ -145,6 +147,7 @@ async function getInitialClips() {
     remix_count: clip.remix_count,
     slug: clip.slug,
     priority: clip.priority,
+    is_tutorial: clip.is_tutorial,
   }));
 }
 

--- a/apps/app/app/admin/clips/components/EditClipModal.tsx
+++ b/apps/app/app/admin/clips/components/EditClipModal.tsx
@@ -38,6 +38,7 @@ export default function EditClipModal({
         prompt: clip.prompt,
         priority: clip.priority,
         approval_status: clip.approval_status,
+        is_tutorial: clip.is_tutorial,
       });
       setSelectedUserName(null);
     } else {
@@ -65,6 +66,11 @@ export default function EditClipModal({
       setFormData(prev => ({
         ...prev,
         [name]: value,
+      }));
+    } else if (name === "is_tutorial") {
+      setFormData(prev => ({
+        ...prev,
+        [name]: value === "true",
       }));
     } else {
       setFormData(prev => ({
@@ -179,6 +185,38 @@ export default function EditClipModal({
 
                 <form onSubmit={handleSubmit} className="mt-4">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="flex flex-col md:flex-row items-center col-span-2 space-y-2 md:space-y-0 md:space-x-4">
+                      <label className="block text-sm font-medium text-gray-700">
+                        Is Tutorial Video
+                      </label>
+                      <div className="flex space-x-4">
+                        <label className="flex items-center gap-2">
+                          <input
+                            type="radio"
+                            name="is_tutorial"
+                            value="true"
+                            checked={formData.is_tutorial === true}
+                            onChange={handleChange}
+                            className="form-radio h-5 w-5 text-blue-600"
+                          />
+                          <span className="text-sm">True</span>
+                        </label>
+                      </div>
+                      <div className="flex space-x-4">
+                        <label className="flex items-center gap-2">
+                          <input
+                            type="radio"
+                            name="is_tutorial"
+                            value="false"
+                            checked={formData.is_tutorial === false}
+                            onChange={handleChange}
+                            className="form-radio h-5 w-5 text-blue-600"
+                          />
+                          <span className="text-sm">False</span>
+                        </label>
+                      </div>
+                    </div>
+
                     <div className="col-span-1">
                       <label className="block text-sm font-medium text-gray-700 mb-1">
                         Approval Status

--- a/apps/app/app/admin/clips/page.tsx
+++ b/apps/app/app/admin/clips/page.tsx
@@ -113,6 +113,7 @@ export default function ClipsAdminPage() {
         "prompt",
         "priority",
         "approval_status",
+        "is_tutorial",
       ];
 
       Object.keys(fieldsToUpdate).forEach(key => {
@@ -204,6 +205,7 @@ export default function ClipsAdminPage() {
       prompt: "",
       created_at: new Date().toISOString(),
       approval_status: "none",
+      is_tutorial: false,
     };
 
     setSelectedClip(newClip);

--- a/apps/app/app/admin/types.ts
+++ b/apps/app/app/admin/types.ts
@@ -29,4 +29,5 @@ export interface Clip {
   deleted_at?: string | null;
   author?: string | { id: string; name: string };
   approval_status: (typeof clipApprovalEnum.enumValues)[number];
+  is_tutorial: boolean;
 }

--- a/apps/app/app/api/admin/clips/route.ts
+++ b/apps/app/app/api/admin/clips/route.ts
@@ -21,6 +21,8 @@ type AdminFetchedClip = {
     id: string;
     name: string | null;
   } | null;
+  approval_status: string | null;
+  is_tutorial: boolean | null;
 };
 
 export async function GET(request: Request) {
@@ -47,6 +49,7 @@ export async function GET(request: Request) {
         id: users.id,
         name: users.name,
       },
+      is_tutorial: clipsTable.is_tutorial,
     };
 
     const prioritizedClips = (await db

--- a/apps/app/app/api/clips/[id]/route.ts
+++ b/apps/app/app/api/clips/[id]/route.ts
@@ -29,6 +29,7 @@ export async function GET(
         author_details: usersTable.additionalDetails,
         created_at: clipsTable.created_at,
         prompt: clipsTable.prompt,
+        is_tutorial: clipsTable.is_tutorial,
       })
       .from(clipsTable)
       .innerJoin(usersTable, eq(clipsTable.author_user_id, usersTable.id))
@@ -68,6 +69,7 @@ export async function GET(
       authorDetails: clip.author_details,
       createdAt: clip.created_at,
       prompt: clip.prompt,
+      isTutorial: clip.is_tutorial,
     });
   } catch (error) {
     console.error("Error fetching clip:", error);

--- a/apps/app/app/api/clips/route.ts
+++ b/apps/app/app/api/clips/route.ts
@@ -96,6 +96,7 @@ export async function GET(request: Request) {
       remix_count: clipsTable.remix_count,
       slug: clipSlugsTable.slug,
       priority: clipsTable.priority,
+      is_tutorial: clipsTable.is_tutorial,
     };
 
     const prioritizedClips = (await db

--- a/apps/app/drizzle/0008_loud_lockjaw.sql
+++ b/apps/app/drizzle/0008_loud_lockjaw.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "clips" ADD COLUMN "is_tutorial" boolean DEFAULT false;

--- a/apps/app/drizzle/meta/0008_snapshot.json
+++ b/apps/app/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1446 @@
+{
+  "id": "0a87a52c-d732-4745-88a9-1505a3d71e1f",
+  "prevId": "c960355c-18bb-450e-b182-a6457fafd9ed",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_fkey": {
+          "name": "api_keys_user_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_amount": {
+          "name": "change_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_fkey": {
+          "name": "audit_logs_user_id_fkey",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clip_slugs": {
+      "name": "clip_slugs",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clip_id": {
+          "name": "clip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "clip_slugs_clip_id_clips_id_fk": {
+          "name": "clip_slugs_clip_id_clips_id_fk",
+          "tableFrom": "clip_slugs",
+          "tableTo": "clips",
+          "columnsFrom": [
+            "clip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clip_views": {
+      "name": "clip_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clip_id": {
+          "name": "clip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_user_id": {
+          "name": "viewer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "clip_views_clip_id_fkey": {
+          "name": "clip_views_clip_id_fkey",
+          "tableFrom": "clip_views",
+          "tableTo": "clips",
+          "columnsFrom": [
+            "clip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "clip_views_viewer_user_id_fkey": {
+          "name": "clip_views_viewer_user_id_fkey",
+          "tableFrom": "clip_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "viewer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clips": {
+      "name": "clips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_title": {
+          "name": "video_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_clip_id": {
+          "name": "source_clip_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remix_count": {
+          "name": "remix_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "clip_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "is_tutorial": {
+          "name": "is_tutorial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "clip_approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "clips_author_user_id_fkey": {
+          "name": "clips_author_user_id_fkey",
+          "tableFrom": "clips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "clips_source_clip_id_fkey": {
+          "name": "clips_source_clip_id_fkey",
+          "tableFrom": "clips",
+          "tableTo": "clips",
+          "columnsFrom": [
+            "source_clip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "clips_approved_by_fkey": {
+          "name": "clips_approved_by_fkey",
+          "tableFrom": "clips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_details": {
+          "name": "pipeline_details",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_s": {
+          "name": "duration_s",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_cost": {
+          "name": "credit_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eth_fees": {
+          "name": "eth_fees",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "jobs_user_id_fkey": {
+          "name": "jobs_user_id_fkey",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "jobs_status_check": {
+          "name": "jobs_status_check",
+          "value": "(status)::text = ANY ((ARRAY['pending'::character varying, 'in-progress'::character varying, 'completed'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pipelines": {
+      "name": "pipelines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'comfyUI'"
+        },
+        "sample_code_repo": {
+          "name": "sample_code_repo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "sample_input_video": {
+          "name": "sample_input_video",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_card": {
+          "name": "model_card",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comfy_ui_json": {
+          "name": "comfy_ui_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "validation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "prioritized_params": {
+          "name": "prioritized_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pipelines_author_fkey": {
+          "name": "pipelines_author_fkey",
+          "tableFrom": "pipelines",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchases": {
+      "name": "purchases",
+      "schema": "",
+      "columns": {
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_purchased": {
+          "name": "credits_purchased",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchases_user_id_fkey": {
+          "name": "purchases_user_id_fkey",
+          "tableFrom": "purchases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_params": {
+      "name": "shared_params",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shared_params_author_fkey": {
+          "name": "shared_params_author_fkey",
+          "tableFrom": "shared_params",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "shared_params_pipeline_fkey": {
+          "name": "shared_params_pipeline_fkey",
+          "tableFrom": "shared_params",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streams": {
+      "name": "streams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stream_key": {
+          "name": "stream_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_stream_url": {
+          "name": "output_stream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pipeline_params": {
+          "name": "pipeline_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_playback_id": {
+          "name": "output_playback_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_playground": {
+          "name": "from_playground",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "gateway_host": {
+          "name": "gateway_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "is_smoke_test": {
+          "name": "is_smoke_test",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "whip_url": {
+          "name": "whip_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "streams_stream_key_idx": {
+          "name": "streams_stream_key_idx",
+          "columns": [
+            {
+              "expression": "stream_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "streams_author_fkey": {
+          "name": "streams_author_fkey",
+          "tableFrom": "streams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "streams_pipeline_id_fkey": {
+          "name": "streams_pipeline_id_fkey",
+          "tableFrom": "streams",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_details": {
+          "name": "additional_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "users_provider_check": {
+          "name": "users_provider_check",
+          "value": "(provider)::text = ANY (ARRAY[('discord'::character varying)::text, ('email'::character varying)::text, ('github'::character varying)::text, ('google'::character varying)::text])"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.clip_approval_status": {
+      "name": "clip_approval_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.clip_status": {
+      "name": "clip_status",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.validation_status": {
+      "name": "validation_status",
+      "schema": "public",
+      "values": [
+        "valid",
+        "invalid",
+        "processing",
+        "pending"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.pg_stat_monitor": {
+      "columns": {
+        "bucket": {
+          "name": "bucket",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_start_time": {
+          "name": "bucket_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userid": {
+          "name": "userid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dbid": {
+          "name": "dbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datname": {
+          "name": "datname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pgsm_query_id": {
+          "name": "pgsm_query_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queryid": {
+          "name": "queryid",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toplevel": {
+          "name": "toplevel",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_queryid": {
+          "name": "top_queryid",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planid": {
+          "name": "planid",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_plan": {
+          "name": "query_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_query": {
+          "name": "top_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_name": {
+          "name": "application_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relations": {
+          "name": "relations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cmd_type": {
+          "name": "cmd_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cmd_type_text": {
+          "name": "cmd_type_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevel": {
+          "name": "elevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sqlcode": {
+          "name": "sqlcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calls": {
+          "name": "calls",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_exec_time": {
+          "name": "total_exec_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_exec_time": {
+          "name": "min_exec_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_exec_time": {
+          "name": "max_exec_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mean_exec_time": {
+          "name": "mean_exec_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stddev_exec_time": {
+          "name": "stddev_exec_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rows": {
+          "name": "rows",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_blks_hit": {
+          "name": "shared_blks_hit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_blks_read": {
+          "name": "shared_blks_read",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_blks_dirtied": {
+          "name": "shared_blks_dirtied",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_blks_written": {
+          "name": "shared_blks_written",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_blks_hit": {
+          "name": "local_blks_hit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_blks_read": {
+          "name": "local_blks_read",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_blks_dirtied": {
+          "name": "local_blks_dirtied",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_blks_written": {
+          "name": "local_blks_written",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_blks_read": {
+          "name": "temp_blks_read",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_blks_written": {
+          "name": "temp_blks_written",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blk_read_time": {
+          "name": "blk_read_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blk_write_time": {
+          "name": "blk_write_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_blk_read_time": {
+          "name": "temp_blk_read_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_blk_write_time": {
+          "name": "temp_blk_write_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resp_calls": {
+          "name": "resp_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_user_time": {
+          "name": "cpu_user_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_sys_time": {
+          "name": "cpu_sys_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wal_records": {
+          "name": "wal_records",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wal_fpi": {
+          "name": "wal_fpi",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wal_bytes": {
+          "name": "wal_bytes",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket_done": {
+          "name": "bucket_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plans": {
+          "name": "plans",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_plan_time": {
+          "name": "total_plan_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_plan_time": {
+          "name": "min_plan_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_plan_time": {
+          "name": "max_plan_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mean_plan_time": {
+          "name": "mean_plan_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stddev_plan_time": {
+          "name": "stddev_plan_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jit_functions": {
+          "name": "jit_functions",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jit_generation_time": {
+          "name": "jit_generation_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jit_inlining_count": {
+          "name": "jit_inlining_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jit_inlining_time": {
+          "name": "jit_inlining_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jit_optimization_count": {
+          "name": "jit_optimization_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jit_optimization_time": {
+          "name": "jit_optimization_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jit_emission_count": {
+          "name": "jit_emission_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jit_emission_time": {
+          "name": "jit_emission_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "SELECT pg_stat_monitor_internal.bucket, pg_stat_monitor_internal.bucket_start_time, pg_stat_monitor_internal.userid, pg_stat_monitor_internal.username, pg_stat_monitor_internal.dbid, pg_stat_monitor_internal.datname, '0.0.0.0'::inet + pg_stat_monitor_internal.client_ip AS client_ip, pg_stat_monitor_internal.pgsm_query_id, pg_stat_monitor_internal.queryid, pg_stat_monitor_internal.toplevel, pg_stat_monitor_internal.top_queryid, pg_stat_monitor_internal.query, pg_stat_monitor_internal.comments, pg_stat_monitor_internal.planid, pg_stat_monitor_internal.query_plan, pg_stat_monitor_internal.top_query, pg_stat_monitor_internal.application_name, string_to_array(pg_stat_monitor_internal.relations, ','::text) AS relations, pg_stat_monitor_internal.cmd_type, get_cmd_type(pg_stat_monitor_internal.cmd_type) AS cmd_type_text, pg_stat_monitor_internal.elevel, pg_stat_monitor_internal.sqlcode, pg_stat_monitor_internal.message, pg_stat_monitor_internal.calls, pg_stat_monitor_internal.total_exec_time, pg_stat_monitor_internal.min_exec_time, pg_stat_monitor_internal.max_exec_time, pg_stat_monitor_internal.mean_exec_time, pg_stat_monitor_internal.stddev_exec_time, pg_stat_monitor_internal.rows, pg_stat_monitor_internal.shared_blks_hit, pg_stat_monitor_internal.shared_blks_read, pg_stat_monitor_internal.shared_blks_dirtied, pg_stat_monitor_internal.shared_blks_written, pg_stat_monitor_internal.local_blks_hit, pg_stat_monitor_internal.local_blks_read, pg_stat_monitor_internal.local_blks_dirtied, pg_stat_monitor_internal.local_blks_written, pg_stat_monitor_internal.temp_blks_read, pg_stat_monitor_internal.temp_blks_written, pg_stat_monitor_internal.shared_blk_read_time AS blk_read_time, pg_stat_monitor_internal.shared_blk_write_time AS blk_write_time, pg_stat_monitor_internal.temp_blk_read_time, pg_stat_monitor_internal.temp_blk_write_time, string_to_array(pg_stat_monitor_internal.resp_calls, ','::text) AS resp_calls, pg_stat_monitor_internal.cpu_user_time, pg_stat_monitor_internal.cpu_sys_time, pg_stat_monitor_internal.wal_records, pg_stat_monitor_internal.wal_fpi, pg_stat_monitor_internal.wal_bytes, pg_stat_monitor_internal.bucket_done, pg_stat_monitor_internal.plans, pg_stat_monitor_internal.total_plan_time, pg_stat_monitor_internal.min_plan_time, pg_stat_monitor_internal.max_plan_time, pg_stat_monitor_internal.mean_plan_time, pg_stat_monitor_internal.stddev_plan_time, pg_stat_monitor_internal.jit_functions, pg_stat_monitor_internal.jit_generation_time, pg_stat_monitor_internal.jit_inlining_count, pg_stat_monitor_internal.jit_inlining_time, pg_stat_monitor_internal.jit_optimization_count, pg_stat_monitor_internal.jit_optimization_time, pg_stat_monitor_internal.jit_emission_count, pg_stat_monitor_internal.jit_emission_time FROM pg_stat_monitor_internal(true) pg_stat_monitor_internal(bucket, userid, username, dbid, datname, client_ip, queryid, planid, query, query_plan, pgsm_query_id, top_queryid, top_query, application_name, relations, cmd_type, elevel, sqlcode, message, bucket_start_time, calls, total_exec_time, min_exec_time, max_exec_time, mean_exec_time, stddev_exec_time, rows, plans, total_plan_time, min_plan_time, max_plan_time, mean_plan_time, stddev_plan_time, shared_blks_hit, shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, temp_blks_written, shared_blk_read_time, shared_blk_write_time, local_blk_read_time, local_blk_write_time, temp_blk_read_time, temp_blk_write_time, resp_calls, cpu_user_time, cpu_sys_time, wal_records, wal_fpi, wal_bytes, comments, jit_functions, jit_generation_time, jit_inlining_count, jit_inlining_time, jit_optimization_count, jit_optimization_time, jit_emission_count, jit_emission_time, jit_deform_count, jit_deform_time, stats_since, minmax_stats_since, toplevel, bucket_done) ORDER BY pg_stat_monitor_internal.bucket_start_time",
+      "name": "pg_stat_monitor",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/app/drizzle/meta/_journal.json
+++ b/apps/app/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1745977765564,
       "tag": "0007_perpetual_dragon_lord",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1746424466073,
+      "tag": "0008_loud_lockjaw",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/app/lib/db/schema.ts
+++ b/apps/app/lib/db/schema.ts
@@ -288,7 +288,7 @@ export const clips = pgTable(
     prompt: text("prompt").notNull(),
     priority: integer("priority"),
     status: clipStatusEnum("status").default("uploading").notNull(),
-
+    is_tutorial: boolean("is_tutorial").default(false),
     approval_status: clipApprovalEnum("approval_status")
       .default("none")
       .notNull(),


### PR DESCRIPTION
- Added `is_tutorial` column to the clips DB table
- Added support to update the flag from admin panel
- Updated the CTA action for tutorial clips and removed the CTA from /clips/<slug> page for such clips
- Added support to copy footer prompt directly by a single click.


https://github.com/user-attachments/assets/ab52696c-53ef-4d42-9957-70f8928ffc4f

## Checklist before merge
- [x] Migrate the Staging DB
- [x] Migrate the Prod DB