### PR TITLE
feat: add events tracking for clips sharing, css fixes

### DIFF
--- a/apps/app/components/daydream/Clipping/ClipShareContent.tsx
+++ b/apps/app/components/daydream/Clipping/ClipShareContent.tsx
@@ -11,6 +11,7 @@ import { CheckIcon, CopyIcon, DownloadIcon } from "lucide-react";
 import { ClipData } from "./types";
 import { toast } from "sonner";
 import useMobileStore from "@/hooks/useMobileStore";
+import { TrackedButton } from "@/components/analytics/TrackedButton";
 
 interface ClipShareContentProps {
   clipData: ClipData;
@@ -136,34 +137,50 @@ export default function ClipShareContent({ clipData }: ClipShareContentProps) {
           value={shareableUrl}
           className="flex-1 rounded-full py-6 px-8 pr-12 overflow-ellipsis"
         />
-        <Button
+        <TrackedButton
+          trackingEvent="daydream_clip_modal_share_clicked"
+          trackingProperties={{
+            method: "unique sharing link",
+          }}
           onClick={handleCopy}
           variant="link"
           className="absolute right-0"
         >
           {copied ? <CheckIcon /> : <CopyIcon />}
-        </Button>
+        </TrackedButton>
       </div>
 
       <p className="text-sm font-light">Share Directly to:</p>
 
       <div className="flex flex-row flex-wrap justify-center items-center gap-5">
-        <button
+        <TrackedButton
+          trackingEvent="daydream_clip_modal_share_clicked"
+          trackingProperties={{
+            method: "download",
+          }}
           onClick={() => handleDownload()}
-          className="animatedGradientButton w-12 h-12 !rounded-full bg-white border-2 border-transparent flex items-center justify-center relative overflow-hidden "
+          className="animatedGradientButton w-12 h-12 !rounded-full bg-white border-2 border-transparent flex items-center justify-center relative overflow-hidden hover:bg-background"
           aria-label="Download clip"
         >
           <DownloadIcon className="w-6 h-6 text-black" />
-        </button>
+        </TrackedButton>
 
-        <button
+        <TrackedButton
+          trackingEvent="daydream_clip_modal_share_clicked"
+          trackingProperties={{
+            method: "tiktok",
+          }}
           onClick={() => handleSocialShare("tiktok")}
           className="w-12 h-12 rounded-full flex items-center justify-center bg-black"
         >
           <TikTokIcon />
-        </button>
+        </TrackedButton>
 
-        <button
+        <TrackedButton
+          trackingEvent="daydream_clip_modal_share_clicked"
+          trackingProperties={{
+            method: "instagram",
+          }}
           onClick={() => handleSocialShare("instagram")}
           className="w-12 h-12 rounded-full flex items-center justify-center overflow-hidden"
           style={{
@@ -172,14 +189,18 @@ export default function ClipShareContent({ clipData }: ClipShareContentProps) {
           }}
         >
           <InstagramIcon />
-        </button>
+        </TrackedButton>
 
-        <button
+        <TrackedButton
+          trackingEvent="daydream_clip_modal_share_clicked"
+          trackingProperties={{
+            method: "X",
+          }}
           onClick={() => handleSocialShare("x")}
           className="w-12 h-12 rounded-full flex items-center justify-center bg-black"
         >
           <XIcon />
-        </button>
+        </TrackedButton>
       </div>
     </DialogContent>
   );
@@ -201,7 +222,7 @@ const InstagramIcon = () => (
 );
 
 const XIcon = () => (
-  <div className="relative w-6 h-6">
+  <div className="relative w-4 h-4">
     <svg
       viewBox="0 0 24 24"
       aria-hidden="true"
@@ -219,7 +240,7 @@ const XIcon = () => (
 );
 
 const TikTokIcon = () => (
-  <div className="relative w-6 h-6">
+  <div className="relative w-4 h-4">
     <svg
       width="24"
       height="24"

--- a/apps/app/components/daydream/Clipping/ClipSummaryContent.tsx
+++ b/apps/app/components/daydream/Clipping/ClipSummaryContent.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import { ClipData } from "./types";
 import { Switch } from "@repo/design-system/components/ui/switch";
 import { usePromptStore } from "@/hooks/usePromptStore";
+import { TrackedButton } from "@/components/analytics/TrackedButton";
 
 interface ClipSummaryContentProps {
   clipData: ClipData;
@@ -146,7 +147,7 @@ export function ClipSummaryContent({
   };
 
   return (
-    <DialogContent className="h-fit max-h-[90dvh] w-[calc(100%-32px)] sm:w-full sm:max-w-[55dvh] mx-auto rounded-xl p-4 pt-5 sm:p-5">
+    <DialogContent className="h-fit max-h-[100dvh] overflow-y-auto w-[calc(100%-32px)] sm:w-full sm:max-w-[55dvh] mx-auto rounded-xl p-4 pt-5 sm:p-5">
       <DialogHeader className="flex items-center mb-1">
         <DialogTitle className="text-xl sm:text-2xl">
           Almost Ready to Share!
@@ -193,13 +194,17 @@ export function ClipSummaryContent({
       </div>
 
       <div className="w-full mt-3">
-        <Button
+        <TrackedButton
+          trackingEvent="daydream_clip_modal_next_clicked"
+          trackingProperties={{
+            submit_to_be_featured: isFeatured,
+          }}
           onClick={handleNext}
           className="w-full items-center justify-center gap-2 rounded-md h-[40px] sm:h-[44px]"
           disabled={isUploading}
         >
           {isUploading ? "Processing..." : "Next"}
-        </Button>
+        </TrackedButton>
       </div>
     </DialogContent>
   );

--- a/apps/app/components/daydream/index.tsx
+++ b/apps/app/components/daydream/index.tsx
@@ -158,6 +158,13 @@ function DaydreamRenderer({ isGuestMode = false }: { isGuestMode?: boolean }) {
           isNewUser ? submitToHubspot(user) : Promise.resolve(),
         ]);
 
+        if (isNewUser) {
+          track("user_account_created", {
+            user_id: user.id,
+            distinct_id: distinctId,
+          });
+        }
+
         track("user_logged_in", {
           user_id: user.id,
           distinct_id: distinctId,


### PR DESCRIPTION
- Added the following events to clip sharing

```
1. "Next" Button Click

Event Name: daydream_clip_modal_next_clicked

Properties:

submit_to_be_featured: true | false (boolean flag based on user selection at time of click)

2. "Share" Button Click

Event Name: daydream_clip_modal_share_clicked

Properties:

method: One of the following string values, depending on which share method was clicked:

"unique sharing link"

"download"

"tiktok"

"instagram"

"X"
```

- Added the following events for new user creation

```
Event Name: account_created
```

- Updated the CSS to handle overflows on smaller screens for clip sharing
<img width="428" alt="Screenshot 2025-05-05 at 7 52 09 PM" src="https://github.com/user-attachments/assets/85dea08b-4d25-47ec-808e-2807d2b57225" />

