### PR TITLE
Change Discord link to new Daydream-specific one

### DIFF
--- a/apps/app/app/(main)/Header.tsx
+++ b/apps/app/app/(main)/Header.tsx
@@ -103,7 +103,7 @@ export default function Header() {
               className="text-sm rounded-md sm:px-4 aspect-square sm:aspect-auto"
               onClick={() => {
                 window.open(
-                  "https://discord.com/invite/hxyNHeSzCK",
+                  "https://discord.gg/DwBPjfhmUt",
                   "_blank",
                   "noopener noreferrer",
                 );

--- a/apps/app/components/header/index.tsx
+++ b/apps/app/components/header/index.tsx
@@ -24,7 +24,7 @@ export default function Header() {
     {
       label: "Community",
       external: true,
-      href: "https://discord.com/invite/hxyNHeSzCK",
+      href: "https://discord.gg/DwBPjfhmUt",
     },
   ];
 

--- a/apps/app/components/modals/capacity-notification-modal.tsx
+++ b/apps/app/components/modals/capacity-notification-modal.tsx
@@ -67,7 +67,7 @@ export function CapacityNotificationModal({
 
   const handleCommunityClick = () => {
     track("capacity_community_clicked");
-    window.open("https://discord.com/invite/hxyNHeSzCK", "_blank");
+    window.open("https://discord.gg/DwBPjfhmUt", "_blank");
   };
 
   const handleModalClose = () => {

--- a/apps/app/components/modals/trial-expired-modal.tsx
+++ b/apps/app/components/modals/trial-expired-modal.tsx
@@ -39,7 +39,7 @@ export function TrialExpiredModal({
               location: "trial_expired_modal",
             }}
             onClick={() =>
-              window.open("https://discord.com/invite/hxyNHeSzCK", "_blank")
+              window.open("https://discord.gg/DwBPjfhmUt", "_blank")
             }
             size="lg"
             className="rounded-full h-12 flex-1 bg-black text-white hover:bg-black/90"

--- a/apps/app/components/modals/unified-signup-modal.tsx
+++ b/apps/app/components/modals/unified-signup-modal.tsx
@@ -180,7 +180,7 @@ export function UnifiedSignupModal({
                 className="w-48 px-12 h-12 rounded-md bg-black text-white hover:bg-gray-800"
                 onClick={() => {
                   window.open(
-                    "https://discord.com/invite/hxyNHeSzCK",
+                    "https://discord.gg/DwBPjfhmUt",
                     "_blank",
                     "noopener noreferrer",
                   );

--- a/apps/app/components/welcome/featured/Header.tsx
+++ b/apps/app/components/welcome/featured/Header.tsx
@@ -98,7 +98,7 @@ export const Header = ({
     <>
       {!isMobile && (
         <div className="fixed top-4 right-4 z-50">
-          <Link target="_blank" href="https://discord.com/invite/hxyNHeSzCK">
+          <Link target="_blank" href="https://discord.gg/DwBPjfhmUt">
             <TrackedButton
               trackingEvent="daydream_join_community_clicked"
               trackingProperties={{
@@ -269,7 +269,7 @@ export const Header = ({
               </Button>
             )}
 
-            <Link target="_blank" href="https://discord.com/invite/hxyNHeSzCK">
+            <Link target="_blank" href="https://discord.gg/DwBPjfhmUt">
               <Button
                 variant="ghost"
                 size="icon"

--- a/apps/app/components/welcome/featured/PlayerOverlay.tsx
+++ b/apps/app/components/welcome/featured/PlayerOverlay.tsx
@@ -92,7 +92,7 @@ export function PlayerOverlay({
 
   const handleCommunityClick = () => {
     track("capacity_community_clicked");
-    window.open("https://discord.com/invite/hxyNHeSzCK", "_blank");
+    window.open("https://discord.gg/DwBPjfhmUt", "_blank");
   };
 
   if (isLoading) {

--- a/apps/app/components/welcome/featured/index.tsx
+++ b/apps/app/components/welcome/featured/index.tsx
@@ -70,7 +70,7 @@ export default function Winners() {
         </div>
         <div>
           <Link
-            href={"https://discord.com/invite/hxyNHeSzCK"}
+            href={"https://discord.gg/DwBPjfhmUt"}
             target="_blank"
             className="text-sm gap-1 flex items-center -ml-20 -mt-8 md:-ml-0 md:-mt-0"
           >

--- a/apps/app/components/welcome/index.tsx
+++ b/apps/app/components/welcome/index.tsx
@@ -173,7 +173,7 @@ const MyStats = () => {
 const CTA = () => {
   return (
     <Link
-      href={"https://discord.com/invite/hxyNHeSzCK"}
+      href={"https://discord.gg/DwBPjfhmUt"}
       target="_blank"
       style={{
         backgroundImage:


### PR DESCRIPTION
We no longer want to direct people to the regular Livepeer Discord 

Context: https://discord.com/channels/423160867534929930/1369370282988408904/1369370286323011624