### PR TITLE
fix: hero text lost on back navigation from quickvideo

### DIFF
--- a/apps/app/app/(main)/QuickviewVideo.tsx
+++ b/apps/app/app/(main)/QuickviewVideo.tsx
@@ -85,6 +85,13 @@ export default function QuickviewVideo({
     }
   }, [pathname]);
 
+  // On unmount, set the preview to false to reset back /explore elements
+  useEffect(() => {
+    return () => {
+      setIsPreviewOpen(false);
+    };
+  }, []);
+
   const handleClose = () => {
     setIsPreviewOpen(false);
     router.push("/", { scroll: false });


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Reset preview state on component unmount

- Prevent hero text loss on back navigation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QuickviewVideo.tsx</strong><dd><code>Add unmount cleanup to reset preview</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/app/(main)/QuickviewVideo.tsx

<li>Introduced cleanup <code>useEffect</code> to reset <code>isPreviewOpen</code><br> <li> Ensures preview closes when component unmounts<br> <li> Stabilizes back navigation behavior for hero text


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/549/files#diff-9b2d3d779da4f71ea5ed4f296c361c48c85497a348afd4eb0b77e209011a37e4">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>