### PR TITLE
fix: shared urls overriden by older inputPrompts

### DIFF
--- a/apps/app/components/welcome/featured/InputPrompt.tsx
+++ b/apps/app/components/welcome/featured/InputPrompt.tsx
@@ -228,7 +228,6 @@ export const InputPrompt = ({ onPromptSubmit }: InputPromptProps) => {
       setLastSubmittedPrompt(inputValue);
       setHasSubmittedPrompt(true);
       setInputValue("");
-      incrementPromptVersion(promptVersion + 1);
     } else {
       console.error("No input value to submit");
     }

--- a/apps/app/components/welcome/featured/MobileInputPrompt.tsx
+++ b/apps/app/components/welcome/featured/MobileInputPrompt.tsx
@@ -235,7 +235,6 @@ export const MobileInputPrompt = ({
       setLastSubmittedPrompt(inputValue);
       setHasSubmittedPrompt(true);
       setInputValue("");
-      incrementPromptVersion(promptVersion + 1);
     } else {
       console.error("No input value to submit");
     }

--- a/apps/app/hooks/useDreamshaper.tsx
+++ b/apps/app/hooks/useDreamshaper.tsx
@@ -17,6 +17,7 @@ import track from "@/lib/track";
 import { usePrivy } from "@/hooks/usePrivy";
 import { usePromptStore } from "@/hooks/usePromptStore";
 import { useCapacityCheck } from "@/hooks/useCapacityCheck";
+import { usePromptVersionStore } from "./usePromptVersionStore";
 
 export const DEFAULT_PIPELINE_ID = "pip_DRQREDnSei4HQyC8"; // Staging Dreamshaper ID
 export const DUMMY_USER_ID_FOR_NON_AUTHENTICATED_USERS =
@@ -404,6 +405,7 @@ export function useParamsHandling() {
 
 export function useStreamUpdates() {
   const { stream, pipeline, setUpdating } = useDreamshaperStore();
+  const { incrementPromptVersion } = usePromptVersionStore();
 
   const handleStreamUpdate = useCallback(
     async (prompt: string, options?: { silent?: boolean }) => {
@@ -532,6 +534,7 @@ export function useStreamUpdates() {
           if (!options?.silent) {
             toast.success("Stream updated successfully", { id: toastId });
           }
+          incrementPromptVersion();
         } else {
           if (!options?.silent) {
             toast.error("Error updating stream with prompt", { id: toastId });

--- a/apps/app/hooks/useDreamshaper.tsx
+++ b/apps/app/hooks/useDreamshaper.tsx
@@ -698,6 +698,8 @@ export const useShareLink = () => {
       }
 
       const shareUrl = new URL(window.location.href);
+      shareUrl.searchParams.delete("inputPrompt");
+      shareUrl.searchParams.delete("sourceClipId");
       shareUrl.searchParams.set("shared", data.id);
 
       return { error: null, url: shareUrl.toString() };

--- a/apps/app/hooks/usePromptVersionStore.ts
+++ b/apps/app/hooks/usePromptVersionStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 interface PromptVersionStore {
   promptVersion: number;
-  incrementPromptVersion: (value: number) => void;
+  incrementPromptVersion: () => void;
 }
 
 export const usePromptVersionStore = create<PromptVersionStore>(set => ({


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove stale query params in share link

- Prevent older prompts overriding new share URLs


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useDreamshaper.tsx</strong><dd><code>Clean share URL of stale parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/hooks/useDreamshaper.tsx

<li>Deleted <code>inputPrompt</code> query parameter before sharing<br> <li> Deleted <code>sourceClipId</code> query parameter before sharing<br> <li> Preserved only <code>shared</code> param with new ID


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/553/files#diff-c85db39fc107de4c2c456afeff72a14135b761684352d62a1f75492c88e94035">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>