### PR TITLE
Remove horizontal separators on clipping modal

### DIFF
--- a/apps/app/components/daydream/Clipping/ClipOptionsModal.tsx
+++ b/apps/app/components/daydream/Clipping/ClipOptionsModal.tsx
@@ -279,8 +279,6 @@ export function ClipOptionsModal({
           </DialogDescription>
         </DialogHeader>
 
-        <Separator className="my-1" />
-
         <RadioGroup
           value={selectedMode}
           onValueChange={handleValueChange}
@@ -304,8 +302,6 @@ export function ClipOptionsModal({
             onSelect={handleValueChange}
           />
         </RadioGroup>
-
-        <Separator className="my-1" />
 
         <div className="w-full">
           <div className="flex gap-2">


### PR DESCRIPTION
### **User description**
Before:
![image](https://github.com/user-attachments/assets/af1d153f-f9b4-4375-8b29-e6a0e77388fb)
After:
<img width="689" alt="image" src="https://github.com/user-attachments/assets/e457597d-26ef-49bd-af63-f4bd92b6e955" />


___

### **PR Type**
Enhancement


___

### **Description**
- Removed separators in share options modal

- Simplified component layout spacing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClipOptionsModal.tsx</strong><dd><code>Remove separators in ClipOptionsModal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/daydream/Clipping/ClipOptionsModal.tsx

<li>Deleted two <Separator> components<br> <li> Maintained spacing around radio group and buttons


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/565/files#diff-83f412bf5af9c045e50f1b80e6e278da7df5b49e99bd154264606350f4a7d8bd">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>