### PR TITLE
feat: align overlay state with actual playback state

### DIFF
--- a/apps/app/components/welcome/featured/Dreamshaper.tsx
+++ b/apps/app/components/welcome/featured/Dreamshaper.tsx
@@ -383,7 +383,7 @@ export default function Dreamshaper({ isGuestMode = false }: DreamshaperProps) {
             >
               {hasCapacity ? (
                 <>
-                  {!showTutorial && !isVisible && <MainContent />}
+                  {(!showTutorial || !isVisible) && <MainContent />}
                   {showTutorial && (
                     <TutorialVideo onComplete={handleTutorialComplete} />
                   )}

--- a/apps/app/components/welcome/featured/MainContent.tsx
+++ b/apps/app/components/welcome/featured/MainContent.tsx
@@ -101,7 +101,7 @@ export const MainContent = () => {
           <div className="relative w-full h-full">
             <LivepeerPlayer />
           </div>
-          {(!live || showOverlay) && <Overlay statusMessage={statusMessage} />}
+          {/* {(!live || showOverlay) && <Overlay statusMessage={statusMessage} />} */}
         </>
       ) : (
         <div className="w-full h-full flex items-center justify-center text-muted-foreground">

--- a/apps/app/components/welcome/featured/MainContent.tsx
+++ b/apps/app/components/welcome/featured/MainContent.tsx
@@ -13,23 +13,23 @@ import {
 import { Loader2, Maximize, Minimize } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useDreamshaperStore } from "../../../hooks/useDreamshaper";
-import { LivepeerPlayer } from "./player";
+import { LivepeerPlayer, usePlayerStore } from "./player";
 import { usePrivy } from "@/hooks/usePrivy";
 import { Logo } from "@/components/sidebar";
 import Overlay from "./Overlay";
 
 export const MainContent = () => {
   const { stream, loading } = useDreamshaperStore();
-  const { live, statusMessage } = useStreamStatus(stream?.id, false);
   const { isMobile } = useMobileStore();
   const { authenticated } = usePrivy();
   const { timeRemaining, formattedTime } = useTrialTimer();
+  const { isPlaying } = usePlayerStore();
   const { isFullscreen, toggleFullscreen } = useFullscreenStore();
 
   const [showOverlay, setShowOverlay] = useState(true);
 
   useEffect(() => {
-    if (live) {
+    if (isPlaying) {
       const timer = setTimeout(() => {
         setShowOverlay(false);
       }, 1000);
@@ -37,7 +37,7 @@ export const MainContent = () => {
     } else {
       setShowOverlay(true);
     }
-  }, [live]);
+  }, [isPlaying]);
 
   return (
     <>
@@ -79,7 +79,7 @@ export const MainContent = () => {
       </Tooltip>
 
       {/* Live indicator*/}
-      {live && (
+      {isPlaying && (
         <div className="absolute top-4 left-4 bg-neutral-800 text-gray-400 px-5 py-1 text-xs rounded-full border border-gray-500">
           <span className="inline-block w-2 h-2 bg-red-500 rounded-full mr-2"></span>
           <span className="text-white font-bold">Live</span>
@@ -101,7 +101,7 @@ export const MainContent = () => {
           <div className="relative w-full h-full">
             <LivepeerPlayer />
           </div>
-          {/* {(!live || showOverlay) && <Overlay statusMessage={statusMessage} />} */}
+          {(!isPlaying || showOverlay) && <Overlay />}
         </>
       ) : (
         <div className="w-full h-full flex items-center justify-center text-muted-foreground">

--- a/apps/app/components/welcome/featured/MainContent.tsx
+++ b/apps/app/components/welcome/featured/MainContent.tsx
@@ -26,19 +26,6 @@ export const MainContent = () => {
   const { isPlaying } = usePlayerStore();
   const { isFullscreen, toggleFullscreen } = useFullscreenStore();
 
-  const [showOverlay, setShowOverlay] = useState(true);
-
-  useEffect(() => {
-    if (isPlaying) {
-      const timer = setTimeout(() => {
-        setShowOverlay(false);
-      }, 1000);
-      return () => clearTimeout(timer);
-    } else {
-      setShowOverlay(true);
-    }
-  }, [isPlaying]);
-
   return (
     <>
       {/* Hide controls for mobile (TODO: when it's a react component,
@@ -101,7 +88,7 @@ export const MainContent = () => {
           <div className="relative w-full h-full">
             <LivepeerPlayer />
           </div>
-          {(!isPlaying || showOverlay) && <Overlay />}
+          {!isPlaying && <Overlay />}
         </>
       ) : (
         <div className="w-full h-full flex items-center justify-center text-muted-foreground">

--- a/apps/app/components/welcome/featured/Overlay.tsx
+++ b/apps/app/components/welcome/featured/Overlay.tsx
@@ -1,10 +1,6 @@
 import { Logo } from "@/components/sidebar";
 import { useEffect, useState } from "react";
 
-interface OverlayProps {
-  statusMessage: string;
-}
-
 const loadingMessages = [
   "Spinning up dream machines...",
   "Unlocking creative dimensions...",
@@ -19,7 +15,7 @@ const loadingMessages = [
   "Stirring the pixel potion...",
 ];
 
-export default function Overlay({ statusMessage }: OverlayProps) {
+export default function Overlay() {
   const [currentMessageIndex, setCurrentMessageIndex] = useState(0);
   const [usedIndices, setUsedIndices] = useState<number[]>([]);
 

--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -24,6 +24,7 @@ import dynamic from "next/dynamic";
 import { useSearchParams } from "next/navigation";
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
+import { create } from "zustand";
 
 const VideoJSPlayer = dynamic(() => import("./videojs-player"), {
   ssr: false,
@@ -37,10 +38,21 @@ const VideoJSPlayer = dynamic(() => import("./videojs-player"), {
   ),
 });
 
+interface PlayerState {
+  isPlaying: boolean;
+  setIsPlaying: (value: boolean) => void;
+}
+
+export const usePlayerStore = create<PlayerState>(set => ({
+  isPlaying: false,
+  setIsPlaying: (value: boolean) => set({ isPlaying: value }),
+}));
+
 export const LivepeerPlayer = () => {
   const { stream, pipeline } = useDreamshaperStore();
   const { isMobile } = useMobileStore();
   const { isFullscreen } = useFullscreenStore();
+  const { setIsPlaying } = usePlayerStore();
   const appConfig = useAppConfig();
   const [playbackInfo, setPlaybackInfo] = useState<PlaybackInfo | null>(null);
 
@@ -142,6 +154,9 @@ export const LivepeerPlayer = () => {
           title="Live stream"
           data-testid="playback-video"
           className={`h-full w-full transition-all object-contain relative z-0 ${!isMobile ? "-scale-x-100" : ""} bg-[#fefefe]`}
+          onLoadedMetadata={() => {
+            setIsPlaying(true);
+          }}
         />
 
         <Player.LoadingIndicator className="w-full relative h-full bg-black/50 backdrop-blur data-[visible=true]:animate-in data-[visible=false]:animate-out data-[visible=false]:fade-out-0 data-[visible=true]:fade-in-0 z-[6]">

--- a/apps/app/hooks/useStreamStatus.ts
+++ b/apps/app/hooks/useStreamStatus.ts
@@ -74,6 +74,7 @@ export const useStreamStatus = (
   const loading = !error && !fullResponse;
   const capacityReached = orchestratorFailureCountRef.current >= 5;
 
+  console.log(fullResponse);
   const live =
     [
       StreamStatus.Online,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Disable overlay display in MainContent

- Comment out Overlay component rendering

- Add debug logging of stream status response


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MainContent.tsx</strong><dd><code>Comment out overlay rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/welcome/featured/MainContent.tsx

<li>Commented out Overlay component rendering<br> <li> Removed conditional overlay display logic


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/567/files#diff-3367bbf9b0ac2d47105440b0d4f3f3e696b38e603eb2ee78d8a0a7b5474b55e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useStreamStatus.ts</strong><dd><code>Add debug log for stream status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/hooks/useStreamStatus.ts

- Added console.log for fullResponse data


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/567/files#diff-0ddea3af5c8a19a21786c10ff6697df35b1054e0395b6010a9fecc93890dfe6e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>