### PR TITLE
fix: reset state on mount

### DIFF
--- a/apps/app/components/welcome/featured/MainContent.tsx
+++ b/apps/app/components/welcome/featured/MainContent.tsx
@@ -11,11 +11,9 @@ import {
   TooltipTrigger,
 } from "@repo/design-system/components/ui/tooltip";
 import { Loader2, Maximize, Minimize } from "lucide-react";
-import { useEffect, useState } from "react";
 import { useDreamshaperStore } from "../../../hooks/useDreamshaper";
 import { LivepeerPlayer, usePlayerStore } from "./player";
 import { usePrivy } from "@/hooks/usePrivy";
-import { Logo } from "@/components/sidebar";
 import Overlay from "./Overlay";
 
 export const MainContent = () => {

--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -59,6 +59,10 @@ export const LivepeerPlayer = () => {
   const { useFallbackPlayer: useFallbackVideoJSPlayer, handleError } =
     useFallbackDetection(stream?.output_playback_id!);
 
+  useEffect(() => {
+    setIsPlaying(false);
+  }, []);
+
   const playerUrl = `${appConfig.whipUrl}${appConfig?.whipUrl?.endsWith("/") ? "" : "/"}${stream?.stream_key}-out/whep`;
 
   const searchParams = useSearchParams();

--- a/apps/app/hooks/useStreamStatus.ts
+++ b/apps/app/hooks/useStreamStatus.ts
@@ -74,7 +74,6 @@ export const useStreamStatus = (
   const loading = !error && !fullResponse;
   const capacityReached = orchestratorFailureCountRef.current >= 5;
 
-  console.log(fullResponse);
   const live =
     [
       StreamStatus.Online,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Reset `isPlaying` on player mount

- Remove unused imports in MainContent


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MainContent.tsx</strong><dd><code>Remove unused imports in MainContent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/welcome/featured/MainContent.tsx

<li>Removed unused <code>useEffect</code> and <code>useState</code> imports<br> <li> Deleted unused <code>Logo</code> import


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/568/files#diff-3367bbf9b0ac2d47105440b0d4f3f3e696b38e603eb2ee78d8a0a7b5474b55e6">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>player.tsx</strong><dd><code>Reset playback state on mount</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/welcome/featured/player.tsx

<li>Added <code>useEffect</code> hook to reset playback state<br> <li> Called <code>setIsPlaying(false)</code> on mount


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/568/files#diff-39a2f82ee81cf06e530436060e70fe21c125a6757cd8110bee3c7d43336f14e5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>