### PR TITLE
feat: add `build:ci` script

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "dev:mock": "NEXT_PUBLIC_USE_PRIVY_MOCK=true pnpm dev",
-    "build": "drizzle-kit push && next build",
+    "build": "next build",
+    "build:ci": "drizzle-kit push && next build",
     "start": "next start",
     "lint": "next lint",
     "analyze": "ANALYZE=true pnpm build",


### PR DESCRIPTION
For issues like those addressed in #584, `build:ci` was added. `build` no longer includes `db:push`.