### PR TITLE
feat: add fallback behavior when no playback url header

### DIFF
--- a/apps/app/app/ServiceWorker.tsx
+++ b/apps/app/app/ServiceWorker.tsx
@@ -5,7 +5,7 @@ import { getSrc } from "@livepeer/react/external";
 import { useEffect } from "react";
 
 export const ServiceWorker = () => {
-  const { setPlaybackUrl } = usePlaybackUrlStore();
+  const { setPlaybackUrl, setLoading } = usePlaybackUrlStore();
 
   useEffect(() => {
     if (typeof window !== "undefined" && "serviceWorker" in navigator) {
@@ -56,6 +56,16 @@ export const ServiceWorker = () => {
             event.data.payload,
           );
           setPlaybackUrl(event.data.payload.headerValue);
+          setLoading(false);
+        }
+
+        if (event.data && event.data.type === "HEADER_NOT_FOUND") {
+          console.debug(
+            "[Service Worker Client]: Message received:",
+            event.data.payload,
+          );
+          setPlaybackUrl(null);
+          setLoading(false);
         }
       };
 

--- a/apps/app/hooks/usePlaybackUrlStore.ts
+++ b/apps/app/hooks/usePlaybackUrlStore.ts
@@ -1,11 +1,15 @@
 import { create } from "zustand";
 
 interface PlaybackUrlStore {
+  loading: boolean;
   playbackUrl: string | null;
   setPlaybackUrl: (url: string | null) => void;
+  setLoading: (loading: boolean) => void;
 }
 
 export const usePlaybackUrlStore = create<PlaybackUrlStore>(set => ({
+  loading: false,
   playbackUrl: null,
   setPlaybackUrl: url => set({ playbackUrl: url }),
+  setLoading: (loading: boolean) => set({ loading }),
 }));

--- a/apps/app/public/sw.js
+++ b/apps/app/public/sw.js
@@ -59,6 +59,16 @@ self.addEventListener("fetch", event => {
                   });
                 }
               });
+          } else {
+            self.clients
+              .matchAll({ type: "window", includeUncontrolled: true })
+              .then(clients => {
+                if (clients && clients.length) {
+                  clients.forEach(client => {
+                    client.postMessage({ type: "HEADER_NOT_FOUND" });
+                  });
+                }
+              });
           }
           return response;
         })


### PR DESCRIPTION
### **User description**
- Fix secondary gateway since it's not returning `livepeer-playback-url` header


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add fallback when playback URL header missing

- Notify clients on missing header condition

- Introduce loading state for player

- Compute whip fallback URL if header absent


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ServiceWorker.tsx</strong><dd><code>Manage loading state in ServiceWorker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/app/ServiceWorker.tsx

<li>Import and use <code>setLoading</code> from playback store<br> <li> Call <code>setLoading(false)</code> on HEADER_FOUND event<br> <li> Handle HEADER_NOT_FOUND event and unset URL<br> <li> Call <code>setLoading(false)</code> when header missing


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/598/files#diff-232cbaef5eed49fa224c49a88aafbdbe899fcc3c1c07879267062857bb0b2550">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>player.tsx</strong><dd><code>Implement playback URL fallback in player</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/welcome/featured/player.tsx

<li>Import <code>useAppConfig</code>, loading flags and setters<br> <li> Set <code>loading=true</code> on mount, reset on unmount<br> <li> Show <code><PlayerLoading /></code> while <code>loading</code> is true<br> <li> Compute <code>playbackUrlWithFallback</code> using <code>whipUrl</code><br> <li> Use fallback URL in VideoJS and source calculations


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/598/files#diff-39a2f82ee81cf06e530436060e70fe21c125a6757cd8110bee3c7d43336f14e5">+16/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>usePlaybackUrlStore.ts</strong><dd><code>Add loading state to playback URL store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/hooks/usePlaybackUrlStore.ts

<li>Introduce <code>loading</code> boolean in store state<br> <li> Add <code>setLoading</code> action to update loading flag


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/598/files#diff-a7c7eea4d5bff4b94f773f2f99a0f2a2e909bb4401e8fe3356a7c13ba05e491e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sw.js</strong><dd><code>Notify clients when header not found</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/public/sw.js

<li>Add <code>else</code> branch for missing header responses<br> <li> Post <code>HEADER_NOT_FOUND</code> message to all window clients


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/598/files#diff-35672d80e944583e83896abef7a3830491a23d4183dc0b8623a88bc876545105">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>