### PR TITLE
Switch to using a Prod post-transformation video stream

### DIFF
--- a/apps/app/components/home/HeroSection.tsx
+++ b/apps/app/components/home/HeroSection.tsx
@@ -167,7 +167,7 @@ export const HeroSection = ({
           }}
         >
           <iframe
-            src={`https://monster.lvpr.tv/?v=${TRANSFORMED_PLAYBACK_ID}&lowLatency=true&backoffMax=1000&ingestPlayback=true&controls=true`}
+            src={`https://lvpr.tv/?v=${TRANSFORMED_PLAYBACK_ID}&lowLatency=true&backoffMax=1000&ingestPlayback=true&controls=true`}
             className="w-full h-full absolute inset-0"
             allow="autoplay; fullscreen"
             allowFullScreen

--- a/apps/app/components/home/VideoSection.tsx
+++ b/apps/app/components/home/VideoSection.tsx
@@ -4,14 +4,14 @@ import React, { useState, useEffect } from "react";
 import { LivepeerPlayer } from "./LivepeerPlayer";
 import { Button } from "@repo/design-system/components/ui/button";
 
-export const TRANSFORMED_PLAYBACK_ID = "95705ossoplg7uvq";
+export const TRANSFORMED_PLAYBACK_ID = "dfdb4lwnbb5ckbls";
 const ORIGINAL_PLAYBACK_ID = "85c28sa2o8wppm58";
 
 export function VideoSection() {
   const [isLoading, setIsLoading] = useState(true);
   const [useLivepeerPlayer, setUseLivepeerPlayer] = useState(false);
 
-  const transformedIframeUrl = `https://monster.lvpr.tv/?v=${TRANSFORMED_PLAYBACK_ID}&lowLatency=true&backoffMax=1000&ingestPlayback=true`;
+  const transformedIframeUrl = `https://lvpr.tv/?v=${TRANSFORMED_PLAYBACK_ID}&lowLatency=true&backoffMax=1000&ingestPlayback=true`;
   const originalIframeUrl = `https://lvpr.tv/?v=${ORIGINAL_PLAYBACK_ID}&lowLatency=false&backoffMax=1000&ingestPlayback=true&muted=true`;
 
   useEffect(() => {


### PR DESCRIPTION
### **User description**
This should eventually use different values for Prod and Staging, but both will use Prod for now


___

### **PR Type**
Enhancement


___

### **Description**
- Switch stream domain to production `lvpr.tv`

- Update `TRANSFORMED_PLAYBACK_ID` value


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HeroSection.tsx</strong><dd><code>Switch HeroSection stream domain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/home/HeroSection.tsx

- Updated iframe src domain to `lvpr.tv`


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/608/files#diff-d4ac1557e3a45df0a774f460d28b7a10ab3b0c32fed936aaa87584db0012ebd8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>VideoSection.tsx</strong><dd><code>Update VideoSection playback ID and domain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/home/VideoSection.tsx

<li>Changed <code>TRANSFORMED_PLAYBACK_ID</code> constant value<br> <li> Updated iframe URL domain to <code>lvpr.tv</code>


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/608/files#diff-b111e52dd9e79873631347b6b63db0d2fe50308f3556fa12df97019b5b4728c6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>