### PR TITLE
perf: enable noICEGathering flag

### DIFF
--- a/apps/app/components/playground/broadcast.tsx
+++ b/apps/app/components/playground/broadcast.tsx
@@ -139,6 +139,7 @@ export function BroadcastWithControls({ className }: { className?: string }) {
       silentAudioTrack
       mirrored={false}
       video
+      noIceGathering
       aspectRatio={16 / 9}
       ingestUrl={ingestUrl}
       {...({


### PR DESCRIPTION
- Re-enabled `noICEGathering`  flag in `Broadcast`, since this check in `ui-kit` does not seem to affect anything.
- **This is a temporary fix**

```ts
async function waitToCompleteICEGathering(peerConnection: RTCPeerConnection) {
  return new Promise<RTCSessionDescription | null>((resolve) => {
    /** Wait at most five seconds for ICE gathering. */
    setTimeout(() => {
      resolve(peerConnection.localDescription);
    }, 5000);
    peerConnection.onicegatheringstatechange = (_ev) => {
      if (peerConnection.iceGatheringState === "complete") {
        resolve(peerConnection.localDescription);
      }
    };
  });
}
```

Potential changes:
```ts
async function waitToCompleteICEGathering(peerConnection: RTCPeerConnection) {
  return new Promise<RTCSessionDescription | null>((resolve) => {
    const originalHandler = peerConnection.onicecandidate;
    peerConnection.onicecandidate = (ev) => {
      if (!ev.candidate) {
        resolve(peerConnection.localDescription);
      }
      if (originalHandler) {
        originalHandler.call(peerConnection, ev);
      }
    };

    setTimeout(() => {
      resolve(peerConnection.localDescription);
    }, 5000);
  });
}
```