### PR TITLE
fix: remove duplicate fullscreen control causing confusion

### DIFF
--- a/apps/app/components/welcome/featured/player.tsx
+++ b/apps/app/components/welcome/featured/player.tsx
@@ -270,16 +270,7 @@ export const LivepeerPlayer = () => {
                 <Player.Thumb className="block transition-all group-hover:scale-110 w-3 h-3 bg-white rounded-full" />
               </Player.Volume>
             </div>
-            <div className="flex sm:flex-1 md:flex-[1.5] justify-end items-center gap-2.5">
-              <Player.FullscreenTrigger className="w-6 h-6 hover:scale-110 transition-all flex-shrink-0">
-                <Player.FullscreenIndicator asChild>
-                  <ExitFullscreenIcon className="w-full h-full text-white" />
-                </Player.FullscreenIndicator>
-                <Player.FullscreenIndicator matcher={false} asChild>
-                  <EnterFullscreenIcon className="w-full h-full text-white" />
-                </Player.FullscreenIndicator>
-              </Player.FullscreenTrigger>
-            </div>
+            <div className="flex sm:flex-1 md:flex-[1.5] justify-end items-center gap-2.5"></div>
           </div>
         </Player.Controls>
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed duplicate fullscreen toggle control

- Cleaned up empty controls container div


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>player.tsx</strong><dd><code>Remove duplicated fullscreen toggle block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/welcome/featured/player.tsx

<li>Deleted duplicated <Player.FullscreenTrigger> block<br> <li> Left container div empty for future controls


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/623/files#diff-39a2f82ee81cf06e530436060e70fe21c125a6757cd8110bee3c7d43336f14e5">+1/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>