### PR TITLE
Don't show trending styles that don't have thumbnails

### DIFF
--- a/apps/app/app/api/clips/route.ts
+++ b/apps/app/app/api/clips/route.ts
@@ -94,6 +94,7 @@ export async function GET(request: Request) {
           isNotNull(clipsTable.priority),
           eq(clipsTable.status, "completed"),
           eq(clipsTable.approval_status, "approved"),
+          isNotNull(clipsTable.thumbnail_url),
         ),
       )
       .orderBy(asc(clipsTable.priority))) as FetchedClip[];
@@ -109,6 +110,7 @@ export async function GET(request: Request) {
           isNull(clipsTable.priority),
           eq(clipsTable.status, "completed"),
           eq(clipsTable.approval_status, "approved"),
+          isNotNull(clipsTable.thumbnail_url),
         ),
       )
       .orderBy(


### PR DESCRIPTION
### **User description**
All new clips should now have them, but old ones don't. This makes the list look bad when they show up


___

### **PR Type**
Bug fix


___

### **Description**
- Filter out thumbnail-less clips from trending list

- Exclude thumbnail-less clips in general list


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Filter out clips missing thumbnails</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/app/api/clips/route.ts

<li>Added <code>isNotNull(clipsTable.thumbnail_url)</code> in trending query<br> <li> Added <code>isNotNull(clipsTable.thumbnail_url)</code> in default query


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/633/files#diff-05046d031e0574cf277770298d7bfe9c4a1260869fd897eeace21e946aeb96b0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>