### PR TITLE
feat: skip HEAD call for WHEP

### DIFF
--- a/apps/app/public/sw.js
+++ b/apps/app/public/sw.js
@@ -13,7 +13,10 @@ self.addEventListener("activate", event => {
 self.addEventListener("fetch", event => {
   const { request } = event;
 
-  if (request.url.includes("/whip") && request.method === "HEAD") {
+  if (
+    (request.url.includes("/whip") || request.url.includes("/whep")) &&
+    request.method === "HEAD"
+  ) {
     event.respondWith(
       new Response(null, {
         status: 405,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Use router.push for navigation in OptimizedVideo

- Streamline LivepeerPlayer playback logic

- Support HEAD on /whep in service worker

- Upgrade @livepeer/react and core-web versions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OptimizedVideo.tsx</strong><dd><code>Switch navigation to router.push</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/app/(main)/OptimizedVideo.tsx

<li>Commented out <code>window.location.href</code><br> <li> Added navigation via <code>router.push</code>


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/642/files#diff-5ffa0213a0484037111e6cc3dfc408e72f0e0ab67d0acfcc70778711c0c9ab64">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>player.tsx</strong><dd><code>Refine LivepeerPlayer loading and src logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/welcome/featured/player.tsx

<li>Show loading when <code>playbackUrl</code> missing<br> <li> Removed fallback URL construction<br> <li> Use <code>playbackUrl</code> directly for src<br> <li> Added <code>key</code> prop to container div


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/642/files#diff-39a2f82ee81cf06e530436060e70fe21c125a6757cd8110bee3c7d43336f14e5">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sw.js</strong><dd><code>Support /whep HEAD in service worker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/public/sw.js

<li>Extended HEAD check to include <code>/whep</code><br> <li> Return 405 for both <code>/whip</code> and <code>/whep</code>


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/642/files#diff-35672d80e944583e83896abef7a3830491a23d4183dc0b8623a88bc876545105">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update @livepeer/react dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/package.json

- Bump `@livepeer/react` to `4.3.5`


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/642/files#diff-15a93da17a40a2a46b85fb22b881b4f9cf1e3df61f06826a7da6e7daa3ba0c66">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pnpm-lock.yaml</strong><dd><code>Refresh lockfile with new lib versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnpm-lock.yaml

<li>Update lock entries for <code>@livepeer/react</code> and <code>@livepeer/core-web</code><br> <li> Adjust resolver integrity and versions


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/642/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+14/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>