### PR TITLE
fix: source url for staging streams

### DIFF
--- a/apps/app/components/home/VideoSection.tsx
+++ b/apps/app/components/home/VideoSection.tsx
@@ -9,18 +9,17 @@ export const TRANSFORMED_PLAYBACK_ID =
   process.env.NEXT_PUBLIC_TRANSFORMED_PLAYBACK_ID ?? "";
 const ORIGINAL_PLAYBACK_ID = process.env.NEXT_PUBLIC_ORIGINAL_PLAYBACK_ID ?? "";
 
-const env = process.env.NEXT_PUBLIC_VERCEL_ENV;
+const env = process.env.NEXT_PUBLIC_ENV;
 
 export function getIframeUrl({
   playbackId,
   lowLatency,
-  isSource,
 }: {
   playbackId: string;
   lowLatency: boolean | "force";
-  isSource?: boolean;
 }) {
-  return `https://${env === "production" || isSource ? "lvpr.tv" : "monster.lvpr.tv"}?v=${playbackId}&lowLatency=${lowLatency}&backoffMax=1000&ingestPlayback=true&controls=true`;
+  const baseUrl = env === "production" ? "lvpr.tv" : "monster.lvpr.tv";
+  return `https://${baseUrl}?v=${playbackId}&lowLatency=${lowLatency}&backoffMax=1000&ingestPlayback=true&controls=true`;
 }
 
 interface VideoSectionProps {
@@ -43,7 +42,6 @@ export function VideoSection({
   const originalIframeUrl = getIframeUrl({
     playbackId: ORIGINAL_PLAYBACK_ID,
     lowLatency: false,
-    isSource: true,
   });
 
   useEffect(() => {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Rename env var to `NEXT_PUBLIC_ENV`

- Remove `isSource` flag in iframe URL function

- Simplify domain selection based on environment


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VideoSection.tsx</strong><dd><code>Simplified iframe URL generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/home/VideoSection.tsx

<li>Updated env var from <code>NEXT_PUBLIC_VERCEL_ENV</code> to <code>NEXT_PUBLIC_ENV</code><br> <li> Removed <code>isSource</code> parameter and its usage<br> <li> Simplified iframe URL domain logic


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/650/files#diff-b111e52dd9e79873631347b6b63db0d2fe50308f3556fa12df97019b5b4728c6">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>