### PR TITLE
test: enable queryparams for APP_URL

### DIFF
--- a/apps/app-e2e/playwright.config.ts
+++ b/apps/app-e2e/playwright.config.ts
@@ -37,8 +37,9 @@ export default defineConfig({
     baseURL: APP_URL,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
+
     extraHTTPHeaders: {
-      Origin: APP_URL!,
+      Origin: new URL(APP_URL!).origin,
     },
   },
 

--- a/apps/app-e2e/tests/common.ts
+++ b/apps/app-e2e/tests/common.ts
@@ -42,7 +42,12 @@ export function selectWhipServer(path: string): string {
   if (REGIONS.length > 0 && Math.random() > 0.49) {
     const region = REGIONS[Math.floor(Math.random() * REGIONS.length)];
     console.log("selected whip region", region);
-    retPath = `${path}?whipServer=https://${region}/live/video-to-video/`;
+    const whipServerParam = `whipServer=https://${region}/live/video-to-video/`;
+    if (retPath.includes("?")) {
+      retPath = `${retPath}&${whipServerParam}`;
+    } else {
+      retPath = `${retPath}?${whipServerParam}`;
+    }
   }
   console.log("generated path for request (with WHIP request)", retPath);
   return retPath;


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
Improve whipServer query parameter logic
Derive `Origin` header from URL origin


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playwright.config.ts</strong><dd><code>Use URL origin for Origin header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app-e2e/playwright.config.ts

• Changed <code>Origin</code> header to <code>new URL(APP_URL!).origin</code><br> • Removed direct <br><code>APP_URL!</code> usage for extraHTTPHeaders


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/664/files#diff-f8631b8ccc32401b56574a0207da5111135d222bddabe41cd0f16841dbdad196">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common.ts</strong><dd><code>Properly append whipServer query parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app-e2e/tests/common.ts

• Extracted <code>whipServerParam</code> variable<br> • Conditionally append <code>?</code> or <code>&</code> for <br>query params


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/664/files#diff-0f23a747b12b99bb2e1fcd89fce66f5b5dfad99b1d6e34cb40444ff691e4370b">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>