### PR TITLE
fix: dreamshaper related hardcode

### DIFF
--- a/apps/app/hooks/useDreamshaper.tsx
+++ b/apps/app/hooks/useDreamshaper.tsx
@@ -413,6 +413,7 @@ export function useParamsHandling() {
 }
 
 export function useStreamUpdates() {
+  const searchParams = useSearchParams();
   const { stream, pipeline, setUpdating } = useDreamshaperStore();
   const { incrementPromptVersion } = usePromptVersionStore();
 
@@ -461,14 +462,22 @@ export function useStreamUpdates() {
         if (!updatedInputValues.prompt) {
           updatedInputValues.prompt = {};
         }
-        if (!updatedInputValues.prompt["5"]) {
-          updatedInputValues.prompt["5"] = { inputs: {} };
-        }
-        if (!updatedInputValues.prompt["5"].inputs) {
-          updatedInputValues.prompt["5"].inputs = {};
-        }
 
-        updatedInputValues.prompt["5"].inputs.text = cleanedPrompt;
+        /**
+         * TODO: Remove once we have a better way to handle this
+         * Hack to get around not attaching the prompt to pipelines which are not dreamshaper
+         * Pass /?isDreamshaper=false to the stream to disable this
+         */
+        if (searchParams.get("isDreamshaper") !== "false") {
+          if (!updatedInputValues.prompt["5"]) {
+            updatedInputValues.prompt["5"] = { inputs: {} };
+          }
+          if (!updatedInputValues.prompt["5"].inputs) {
+            updatedInputValues.prompt["5"].inputs = {};
+          }
+
+          updatedInputValues.prompt["5"].inputs.text = cleanedPrompt;
+        }
 
         if (
           freshPipeline?.prioritized_params &&


### PR DESCRIPTION
### **User description**
Allows testing other pipelines by not blocking them due to passing prompt data in a certain dreamshaper node.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `isDreamshaper` URL param check

- Wrap prompt injection for pipeline "5"

- Remove unconditional hardcoded injection

- Introduce TODO for future refactor


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useDreamshaper.tsx</strong><dd><code>Conditional prompt injection for Dreamshaper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/hooks/useDreamshaper.tsx

<li>Added <code>useSearchParams</code> hook usage<br> <li> Wrapped pipeline "5" prompt injection in condition<br> <li> Removed unconditional <code>prompt["5"].inputs.text</code> assignment<br> <li> Added TODO comment for future cleanup


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/666/files#diff-c85db39fc107de4c2c456afeff72a14135b761684352d62a1f75492c88e94035">+16/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>