### PR TITLE
Fix prompt list only showing oldest prompts on mobile

### DIFF
--- a/apps/app/components/home/PromptDisplay.tsx
+++ b/apps/app/components/home/PromptDisplay.tsx
@@ -141,8 +141,23 @@ export function PromptDisplay({
     let itemCount = 0;
     const maxItems = MAX_MOBILE_PROMPTS;
 
-    if (nonHighlightedPrompts.length > 0) {
-      const recentPastPrompts = nonHighlightedPrompts.slice(0, maxItems - 1);
+    // Add highlighted prompt first
+    if (highlightedPrompt) {
+      itemsToShow.push({
+        type: "highlighted",
+        text: highlightedPrompt,
+        isUser: userPromptIndices[0],
+        seed: promptAvatarSeeds[0],
+      });
+      itemCount++;
+    }
+
+    // Then add past prompts in correct order (newest to oldest)
+    if (nonHighlightedPrompts.length > 0 && itemCount < maxItems) {
+      const recentPastPrompts = nonHighlightedPrompts.slice(
+        0,
+        maxItems - itemCount,
+      );
 
       recentPastPrompts.forEach((prompt, idx) => {
         const isUserPrompt = userPromptIndices[idx + 1];
@@ -154,22 +169,11 @@ export function PromptDisplay({
           isUser: isUserPrompt,
           seed: seed,
         });
-
         itemCount++;
       });
     }
 
-    if (itemCount < maxItems && highlightedPrompt) {
-      itemsToShow.push({
-        type: "highlighted",
-        text: highlightedPrompt,
-        isUser: userPromptIndices[0],
-        seed: promptAvatarSeeds[0],
-      });
-
-      itemCount++;
-    }
-
+    // Finally add queue items if there's still space
     if (itemCount < maxItems && nonEmptyQueueItems.length > 0) {
       const queueItemsToShow = nonEmptyQueueItems.slice(
         0,

--- a/apps/app/components/home/PromptDisplay.tsx
+++ b/apps/app/components/home/PromptDisplay.tsx
@@ -142,14 +142,11 @@ export function PromptDisplay({
     const maxItems = MAX_MOBILE_PROMPTS;
 
     if (nonHighlightedPrompts.length > 0) {
-      const reversedPastPrompts = [...nonHighlightedPrompts].reverse();
-      const pastPromptsToShow = reversedPastPrompts.slice(0, maxItems - 1);
+      const recentPastPrompts = nonHighlightedPrompts.slice(0, maxItems - 1);
 
-      pastPromptsToShow.forEach(prompt => {
-        const index =
-          nonHighlightedPrompts.length - reversedPastPrompts.indexOf(prompt);
-        const isUserPrompt = userPromptIndices[index];
-        const seed = promptAvatarSeeds[index];
+      recentPastPrompts.forEach((prompt, idx) => {
+        const isUserPrompt = userPromptIndices[idx + 1];
+        const seed = promptAvatarSeeds[idx + 1];
 
         itemsToShow.push({
           type: "past",

--- a/apps/app/components/home/PromptDisplay.tsx
+++ b/apps/app/components/home/PromptDisplay.tsx
@@ -143,13 +143,13 @@ export function PromptDisplay({
 
     // Create a combined chronological order list (oldest to newest, including current)
     const allPromptsChronological = [];
-    
+
     // First add past prompts in reverse chronological order (oldest first)
     if (nonHighlightedPrompts.length > 0) {
       // nonHighlightedPrompts is already in reverse chronological order (newest first)
       // so we need to reverse it to get oldest first
       const oldestToNewest = [...nonHighlightedPrompts].reverse();
-      
+
       // Add all the past prompts (they'll be oldest to newest)
       oldestToNewest.forEach((prompt, idx) => {
         const originalIndex = nonHighlightedPrompts.length - idx;
@@ -161,7 +161,7 @@ export function PromptDisplay({
         });
       });
     }
-    
+
     // Then add highlighted prompt (which is the newest)
     if (highlightedPrompt) {
       allPromptsChronological.push({
@@ -171,7 +171,7 @@ export function PromptDisplay({
         seed: promptAvatarSeeds[0],
       });
     }
-    
+
     // Take only the most recent N items to fit into our display
     itemsToShow = allPromptsChronological.slice(-maxItems);
     itemCount = itemsToShow.length;

--- a/apps/app/components/home/PromptDisplay.tsx
+++ b/apps/app/components/home/PromptDisplay.tsx
@@ -141,39 +141,42 @@ export function PromptDisplay({
     let itemCount = 0;
     const maxItems = MAX_MOBILE_PROMPTS;
 
-    // Add highlighted prompt first
+    // Create a combined chronological order list (oldest to newest, including current)
+    const allPromptsChronological = [];
+    
+    // First add past prompts in reverse chronological order (oldest first)
+    if (nonHighlightedPrompts.length > 0) {
+      // nonHighlightedPrompts is already in reverse chronological order (newest first)
+      // so we need to reverse it to get oldest first
+      const oldestToNewest = [...nonHighlightedPrompts].reverse();
+      
+      // Add all the past prompts (they'll be oldest to newest)
+      oldestToNewest.forEach((prompt, idx) => {
+        const originalIndex = nonHighlightedPrompts.length - idx;
+        allPromptsChronological.push({
+          type: "past",
+          text: prompt,
+          isUser: userPromptIndices[originalIndex],
+          seed: promptAvatarSeeds[originalIndex],
+        });
+      });
+    }
+    
+    // Then add highlighted prompt (which is the newest)
     if (highlightedPrompt) {
-      itemsToShow.push({
+      allPromptsChronological.push({
         type: "highlighted",
         text: highlightedPrompt,
         isUser: userPromptIndices[0],
         seed: promptAvatarSeeds[0],
       });
-      itemCount++;
     }
+    
+    // Take only the most recent N items to fit into our display
+    itemsToShow = allPromptsChronological.slice(-maxItems);
+    itemCount = itemsToShow.length;
 
-    // Then add past prompts in correct order (newest to oldest)
-    if (nonHighlightedPrompts.length > 0 && itemCount < maxItems) {
-      const recentPastPrompts = nonHighlightedPrompts.slice(
-        0,
-        maxItems - itemCount,
-      );
-
-      recentPastPrompts.forEach((prompt, idx) => {
-        const isUserPrompt = userPromptIndices[idx + 1];
-        const seed = promptAvatarSeeds[idx + 1];
-
-        itemsToShow.push({
-          type: "past",
-          text: prompt,
-          isUser: isUserPrompt,
-          seed: seed,
-        });
-        itemCount++;
-      });
-    }
-
-    // Finally add queue items if there's still space
+    // Add queue items if there's still space
     if (itemCount < maxItems && nonEmptyQueueItems.length > 0) {
       const queueItemsToShow = nonEmptyQueueItems.slice(
         0,


### PR DESCRIPTION
This fixes an issue where we were only showing the oldest 3 prompts on mobile rather than the most recent 3.

Remaining issue of a submitted prompt disappearing until it becomes active will be resolved in a followup PR.