### PR TITLE
Display mobile prompt immediately after submitting

### DIFF
--- a/apps/app/components/home/PromptDisplay.tsx
+++ b/apps/app/components/home/PromptDisplay.tsx
@@ -174,15 +174,29 @@ export function PromptDisplay({
 
     // Add queue items first, before limiting the display size
     if (nonEmptyQueueItems.length > 0) {
+      // Add queue items in chronological order (oldest first)
+      // nonEmptyQueueItems should already be sorted by position/timestamp
       nonEmptyQueueItems.forEach(item => {
         allPromptsChronological.push({
           type: "queue",
           text: item.text,
           isUser: item.isUser,
           seed: item.seed,
+          timestamp: item.timestamp,
         });
       });
     }
+
+    // Sort all prompts by timestamp to ensure correct chronological order
+    allPromptsChronological.sort((a, b) => {
+      // Past prompts and highlighted prompt don't have timestamps, so we 
+      // maintain their existing order (they're already in chronological order)
+      if (a.type === "queue" && b.type === "queue") {
+        return a.timestamp - b.timestamp;
+      }
+      // Keep existing order for non-queue items
+      return 0;
+    });
 
     // Take only the most recent N items to fit into our display
     itemsToShow = allPromptsChronological.slice(-maxItems);
@@ -289,7 +303,10 @@ export function PromptDisplay({
 
         {nonEmptyQueueItems.length > 0 && (
           <div className="hidden md:flex flex-col gap-2 w-full">
-            {nonEmptyQueueItems.map((queuedPrompt, qIndex) => {
+            {nonEmptyQueueItems
+              // Sort queue items by timestamp to ensure chronological order
+              .sort((a, b) => a.timestamp - b.timestamp)
+              .map((queuedPrompt, qIndex) => {
               const username = queuedPrompt.seed
                 ? generateUsername(queuedPrompt.seed)
                 : "User";

--- a/apps/app/components/home/PromptDisplay.tsx
+++ b/apps/app/components/home/PromptDisplay.tsx
@@ -172,19 +172,10 @@ export function PromptDisplay({
       });
     }
 
-    // Take only the most recent N items to fit into our display
-    itemsToShow = allPromptsChronological.slice(-maxItems);
-    itemCount = itemsToShow.length;
-
-    // Add queue items if there's still space
-    if (itemCount < maxItems && nonEmptyQueueItems.length > 0) {
-      const queueItemsToShow = nonEmptyQueueItems.slice(
-        0,
-        maxItems - itemCount,
-      );
-
-      queueItemsToShow.forEach(item => {
-        itemsToShow.push({
+    // Add queue items first, before limiting the display size
+    if (nonEmptyQueueItems.length > 0) {
+      nonEmptyQueueItems.forEach(item => {
+        allPromptsChronological.push({
           type: "queue",
           text: item.text,
           isUser: item.isUser,
@@ -192,6 +183,10 @@ export function PromptDisplay({
         });
       });
     }
+
+    // Take only the most recent N items to fit into our display
+    itemsToShow = allPromptsChronological.slice(-maxItems);
+    itemCount = itemsToShow.length;
 
     return (
       <div className="w-full flex flex-col justify-end p-4 overflow-y-auto overflow-x-hidden">

--- a/apps/app/components/home/PromptDisplay.tsx
+++ b/apps/app/components/home/PromptDisplay.tsx
@@ -174,29 +174,15 @@ export function PromptDisplay({
 
     // Add queue items first, before limiting the display size
     if (nonEmptyQueueItems.length > 0) {
-      // Add queue items in chronological order (oldest first)
-      // nonEmptyQueueItems should already be sorted by position/timestamp
       nonEmptyQueueItems.forEach(item => {
         allPromptsChronological.push({
           type: "queue",
           text: item.text,
           isUser: item.isUser,
           seed: item.seed,
-          timestamp: item.timestamp,
         });
       });
     }
-
-    // Sort all prompts by timestamp to ensure correct chronological order
-    allPromptsChronological.sort((a, b) => {
-      // Past prompts and highlighted prompt don't have timestamps, so we 
-      // maintain their existing order (they're already in chronological order)
-      if (a.type === "queue" && b.type === "queue") {
-        return a.timestamp - b.timestamp;
-      }
-      // Keep existing order for non-queue items
-      return 0;
-    });
 
     // Take only the most recent N items to fit into our display
     itemsToShow = allPromptsChronological.slice(-maxItems);
@@ -303,10 +289,7 @@ export function PromptDisplay({
 
         {nonEmptyQueueItems.length > 0 && (
           <div className="hidden md:flex flex-col gap-2 w-full">
-            {nonEmptyQueueItems
-              // Sort queue items by timestamp to ensure chronological order
-              .sort((a, b) => a.timestamp - b.timestamp)
-              .map((queuedPrompt, qIndex) => {
+            {nonEmptyQueueItems.map((queuedPrompt, qIndex) => {
               const username = queuedPrompt.seed
                 ? generateUsername(queuedPrompt.seed)
                 : "User";


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add queue items before limiting prompts display

- Remove old slice-and-fill queue logic

- Simplify chronological prompt merging


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PromptDisplay.tsx</strong><dd><code>Merge queue items before slicing display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/home/PromptDisplay.tsx

<li>Moved queue items addition before display size slicing<br> <li> Removed separate queue filling block after slice<br> <li> Adjusted slicing to occur after merging all prompts


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/672/files#diff-c731e9a8780fa29a84f027a1b48afd5a44b588dd4ecdf63d8f1ffd2d47813786">+8/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>