### PR TITLE
Add 'trending' prompts

### DIFF
--- a/apps/app/components/home/PromptPanel.tsx
+++ b/apps/app/components/home/PromptPanel.tsx
@@ -1,5 +1,5 @@
-import React, { RefObject } from "react";
-import { Camera } from "lucide-react";
+import React, { RefObject, useMemo } from "react";
+import { Camera, Flame, TrendingUp } from "lucide-react";
 import { DiscordLogoIcon } from "@radix-ui/react-icons";
 import { PromptForm } from "./PromptForm";
 import { PromptDisplay } from "./PromptDisplay";
@@ -51,6 +51,97 @@ export function PromptPanel({
     window.open("https://discord.gg/5sZu8xmn6U", "_blank");
   };
 
+  // Full list of trending prompts
+  const allTrendingPrompts = [
+    {
+      display: "Guybrush Threepwood",
+      prompt:
+        "guybrush threepwood ((flat color)) studio ghibli --creativity 0.4 --quality 2",
+    },
+    {
+      display: "Bender Robot",
+      prompt:
+        "bender robot ((flat color)) studio ghibli --creativity 0.3 --quality 5",
+    },
+    {
+      display: "Vitruvian Blueprint",
+      prompt:
+        "((blueprint)) vitruvian ((flat colors)) --creativity 0.35 --quality 5 --denoise 0.9",
+    },
+    {
+      display: "Claymation Muppet",
+      prompt:
+        "sculpture ((claymation)) muppet sunglasses --creativity 0.6 --quality 3",
+    },
+    {
+      display: "Studio Ghibli",
+      prompt: "studio ghibli (watercolor) :: ((flat colors)) --quality 3",
+    },
+    {
+      display: "Seraphim",
+      prompt:
+        "no face, multiple eyes on face and body,Seraphim ((flat colors)) --quality 3 --creativity 0.3",
+    },
+    {
+      display: "Water Life Form",
+      prompt:
+        "(organic water life form:1.2) :: flowing liquid :: futuristic :: darkfantasy :: merfolk --creativity 0.4",
+    },
+    {
+      display: "Bender Studio",
+      prompt:
+        "bender robot ((flat color)) studio ghibli --creativity 0.3 --quality 2",
+    },
+    {
+      display: "Anime Style",
+      prompt:
+        "anime-style illustration, detailed line art, vibrant colors, large expressive eyes, cel-shading, soft lighting, cinematic composition, dynamic pose --quality 3",
+    },
+    {
+      display: "Ink Art",
+      prompt:
+        "((ink illustration, clean linework, sharp contrast)) :: cyan, magenta, chartreuse, orange :: high resolution, bold color separation --quality 5 --creativity 0.6",
+    },
+    {
+      display: "Polar Bear",
+      prompt:
+        "a sad white (polar bear) sitting in antarctica, front view --quality 5",
+    },
+    {
+      display: "Cubist Portrait",
+      prompt:
+        "((cubism)) Taylor swift ((flat colors)) --creativity 0.6 --quality 3",
+    },
+    {
+      display: "Young Frankenstein",
+      prompt:
+        "Young Frankenstein Gene Wilder ((lightning)) black and white --quality 3 --creativity 0.65",
+    },
+    {
+      display: "Bohemian Rhapsody",
+      prompt: "bohemian rhapsody, black background, illuminated faces",
+    },
+    {
+      display: "Yoda",
+      prompt:
+        "(yoda:1.2), Star Wars, Brown Robe, Green Skin, Big Ears, (Green Light Saber:1.2) --denoise 1.0 --creativity 1.0 --negative-prompt human",
+    },
+    {
+      display: "Frankenstein",
+      prompt: "frankenstein ((lightning)) --quality 3 --creativity 0.6",
+    },
+  ];
+
+  // Randomly select 3 prompts on each render
+  const trendingPrompts = useMemo(() => {
+    const shuffled = [...allTrendingPrompts].sort(() => Math.random() - 0.5);
+    return shuffled.slice(0, 3);
+  }, []);
+
+  const handleTrendingPromptClick = (prompt: string) => {
+    setPromptValue(prompt);
+  };
+
   // Calculate the height of the input container on mobile (approximately 76px)
   // 44px input height + 2 * 16px padding (p-4) = 76px
   const inputBoxHeight = 76;
@@ -90,6 +181,43 @@ export function PromptPanel({
           {buttonText}
         </TrackedButton>
       </div>
+
+      {/* Trending prompts section - completely separate box */}
+      {!isMobile && (
+        <div className="w-full mb-3">
+          <div
+            className="w-full bg-white rounded-lg p-3"
+            style={{
+              boxShadow: "0 2px 6px rgba(0,0,0,0.05)",
+              borderRadius: "8px",
+            }}
+          >
+            <div className="flex items-center gap-1.5 mb-3">
+              <Flame className="h-4 w-4 text-orange-500" />
+              <div className="text-sm font-semibold text-black">Trending</div>
+            </div>
+            <div className="flex gap-2">
+              {trendingPrompts.map((item, index) => (
+                <TrackedButton
+                  key={index}
+                  variant="outline"
+                  size="sm"
+                  className="alwaysAnimatedButton rounded-md text-xs flex-1 min-w-0"
+                  onClick={() => handleTrendingPromptClick(item.prompt)}
+                  trackingEvent="trending_prompt_clicked"
+                  trackingProperties={{
+                    prompt_text: item.prompt,
+                    display_text: item.display,
+                    index,
+                  }}
+                >
+                  <span className="truncate">{item.display}</span>
+                </TrackedButton>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
 
       {isMobile && (
         <div
@@ -176,7 +304,7 @@ export function PromptPanel({
             )}
 
             {!isMobile && (
-              <div className="flex-1 flex flex-col justify-end overflow-hidden relative">
+              <div className="flex-1 flex flex-col justify-end overflow-hidden relative max-h-[50vh]">
                 <>
                   <div
                     className="absolute top-0 left-0 right-0 h-[60%] pointer-events-none z-30"
@@ -203,6 +331,7 @@ export function PromptPanel({
                         "linear-gradient(to bottom, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 40%, rgba(0,0,0,0.8) 60%, rgba(0,0,0,0.4) 80%, rgba(0,0,0,0.05) 90%, rgba(0,0,0,0) 100%)",
                     }}
                   ></div>
+
                   <PromptDisplay
                     promptQueue={promptQueue}
                     displayedPrompts={displayedPrompts}


### PR DESCRIPTION
### **User description**
Driven by a hardcoded list to begin with, randomising three at a time to show.

Desktop-only for now, to avoid conflicts with in-flight reworking of the mobile UI.

Records which prompt is clicked and its index (0, 1 or 2) whenever someone uses one.

___

### **PR Type**
Enhancement


___

### **Description**
Add desktop-only trending prompts panel
Display three random prompts each render
Track prompt selection events
Constrain prompt display height on desktop


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PromptPanel.tsx</strong><dd><code>Desktop trending prompts panel integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/home/PromptPanel.tsx

<li>Imported <code>useMemo</code>, <code>Flame</code>, <code>TrendingUp</code> icons<br> <li> Defined <code>allTrendingPrompts</code> and random selection logic<br> <li> Rendered new desktop-only trending prompts section<br> <li> Added max height constraint (<code>max-h-[50vh]</code>) on prompt display


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/695/files#diff-413b164c05da992879f8060db4d12e68094b924894b051fd5bd94bbcc54ce266">+132/-3</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>