### PR TITLE
fix: footer padding fix on prompt panel

### DIFF
--- a/apps/app/components/home/PromptForm.tsx
+++ b/apps/app/components/home/PromptForm.tsx
@@ -96,7 +96,7 @@ export const PromptForm = forwardRef<HTMLFormElement, PromptFormProps>(
       <form
         ref={formRef}
         onSubmit={handleSubmit}
-        className={`pt-0 relative z-10 px-4 ${isMobile ? "px-0 bg-transparent py-2" : "md:border-b border-t md:border-t-0 border-gray-200/30"}`}
+        className={`pt-0 relative z-10 px-4 ${isMobile ? "px-0 bg-transparent py-2" : "pb-4 md:border-b border-t md:border-t-0 border-gray-200/30"}`}
       >
         <div className="relative">
           <Textarea


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add `pb-4` to non-mobile PromptForm wrapper

- Preserve mobile padding and transparent background


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PromptForm.tsx</strong><dd><code>Add bottom padding to PromptForm on desktop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/home/PromptForm.tsx

<li>Insert <code>pb-4</code> for bottom padding on desktop forms<br> <li> Maintain existing mobile <code>py-2</code> and transparent background<br> <li> Keep original border classes for non-mobile


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/717/files#diff-9149b635e2d096af2b17c2bc132ad9678c68282a6d571b1535f9473aa8c6f651">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>