### PR TITLE
Disable e2e retries for now

### DIFF
--- a/apps/app-e2e/playwright.config.ts
+++ b/apps/app-e2e/playwright.config.ts
@@ -25,8 +25,6 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -35,8 +33,8 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: APP_URL,
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on-first-retry",
+    /* Collect trace for failed tests. See https://playwright.dev/docs/trace-viewer */
+    trace: "retain-on-failure",
 
     extraHTTPHeaders: {
       Origin: new URL(APP_URL!).origin,


### PR DESCRIPTION
Retries were making debugging a little tricky because the screenshots would be overwritten if a retry passed so disable for now