### PR TITLE
Just check the maximum frame difference

### DIFF
--- a/apps/app-e2e/tests/common.ts
+++ b/apps/app-e2e/tests/common.ts
@@ -249,6 +249,7 @@ export async function assertVideoContentChanging(
   await test.step("Verify inter-frame differences (content changing)", async () => {
     const pixelmatch = (await import("pixelmatch")).default;
 
+    let maxDiffPercent = 0;
     for (let i = 0; i < processedFrames.length - 1; i++) {
       const buffer1 = processedFrames[i].buffer;
       const buffer2 = processedFrames[i + 1].buffer;
@@ -274,11 +275,14 @@ export async function assertVideoContentChanging(
       totalDiffRatio += diffPercent;
       pairCount++;
 
-      expect(
-        diffPercent,
-        `Frames ${i}→${i + 1} (${videoType}) changed only ${(diffPercent * 100).toFixed(2)}%, should exceed ${(MIN_DIFF_RATIO_THRESHOLD * 100).toFixed(2)}%`,
-      ).toBeGreaterThan(MIN_DIFF_RATIO_THRESHOLD);
+      if (diffPercent > maxDiffPercent) {
+        maxDiffPercent = diffPercent;
+      }
     }
+    expect(
+      maxDiffPercent,
+      `Frames changed only ${(maxDiffPercent * 100).toFixed(2)}%, should exceed ${(MIN_DIFF_RATIO_THRESHOLD * 100).toFixed(2)}%`,
+    ).toBeGreaterThan(MIN_DIFF_RATIO_THRESHOLD);
   });
 
   await test.step("Calculate averages and set Prometheus metrics", async () => {


### PR DESCRIPTION
### **User description**
Verifying the difference for every frame snapshot seemed a bit too strict as we were getting false positives for this on the broadcast component quite often


___

### **PR Type**
Tests


___

### **Description**
- Replace per-frame diff checks with single max check

- Track maximum inter-frame difference in `maxDiffPercent`

- Move threshold assertion outside the loop


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common.ts</strong><dd><code>Use max diff threshold assertion in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app-e2e/tests/common.ts

• Introduce <code>maxDiffPercent</code> variable for max diff tracking  <br> • Remove per-frame <code>expect(diffPercent).toBeGreaterThan</code> checks  <br> • Add single <code>expect(maxDiffPercent).toBeGreaterThan</code> assertion


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/732/files#diff-0f23a747b12b99bb2e1fcd89fce66f5b5dfad99b1d6e34cb40444ff691e4370b">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>