### PR TITLE
prompt_text -> prompt in metric property for consistency

### DIFF
--- a/apps/app/components/home/PromptPanel.tsx
+++ b/apps/app/components/home/PromptPanel.tsx
@@ -182,7 +182,7 @@ export function PromptPanel({
                   onClick={() => handleTrendingPromptClick(item.prompt)}
                   trackingEvent="trending_prompt_clicked"
                   trackingProperties={{
-                    prompt_text: item.prompt,
+                    prompt: item.prompt,
                     display_text: item.display,
                     index,
                   }}
@@ -260,7 +260,7 @@ export function PromptPanel({
               onClick={() => handleTrendingPromptClick(item.prompt)}
               trackingEvent="trending_prompt_clicked"
               trackingProperties={{
-                prompt_text: item.prompt,
+                prompt: item.prompt,
                 display_text: item.display,
                 index,
               }}


### PR DESCRIPTION
### **User description**
This is the tag name we use on all our other metrics


___

### **PR Type**
Bug fix


___

### **Description**
- Rename tracking property `prompt_text` to `prompt`

- Apply change to both button variants


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PromptPanel.tsx</strong><dd><code>Rename tracking property key to prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/app/components/home/PromptPanel.tsx

<li>Replaced <code>prompt_text</code> with <code>prompt</code> in trackingProperties<br> <li> Updated two button variants for consistency


</details>


  </td>
  <td><a href="https://github.com/livepeer/pipelines/pull/733/files#diff-413b164c05da992879f8060db4d12e68094b924894b051fd5bd94bbcc54ce266">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>